### PR TITLE
Use a Cached ContentLoader in DomainContentResolver

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/GraphQL/Resolver/DomainContentResolverSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/GraphQL/Resolver/DomainContentResolverSpec.php
@@ -3,6 +3,8 @@
 namespace spec\EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader;
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentTypeLoader;
 use EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQueryMapper;
 use EzSystems\EzPlatformGraphQL\GraphQL\Resolver\DomainContentResolver;
 use eZ\Publish\API\Repository\Repository;
@@ -14,9 +16,11 @@ class DomainContentResolverSpec extends ObjectBehavior
     function let(
         Repository $repository,
         TypeResolver $typeResolver,
-        SearchQueryMapper $searchQueryMapper
+        SearchQueryMapper $queryMapper,
+        ContentLoader $contentLoader,
+        ContentTypeLoader $contentTypeLoader
     ) {
-        $this->beConstructedWith($repository, $typeResolver, $searchQueryMapper);
+        $this->beConstructedWith($repository, $typeResolver, $queryMapper, $contentLoader, $contentTypeLoader);
     }
 
     function it_is_initializable()

--- a/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
+++ b/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
@@ -40,6 +40,7 @@ class EzSystemsEzPlatformGraphQLExtension extends Extension implements PrependEx
         $loader->load('services.yml');
         $loader->load('services/mutations.yml');
         $loader->load('default_settings.yml');
+        $loader->load('services/data_loaders.yml');
     }
 
     /**

--- a/src/GraphQL/DataLoader/CachedContentLoader.php
+++ b/src/GraphQL/DataLoader/CachedContentLoader.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+class CachedContentLoader implements ContentLoader
+{
+    /**
+     * @var ContentLoader
+     */
+    private $innerLoader;
+
+    private $loadedItems = [];
+
+    public function __construct(ContentLoader $innerLoader)
+    {
+        $this->innerLoader = $innerLoader;
+    }
+
+    public function find(Query $query): array
+    {
+        $items = $this->innerLoader->find($query);
+
+        foreach ($items as $item) {
+            $this->loadedItems[$item->id] = $item;
+        }
+
+        return $items;
+    }
+
+    public function findSingle(Criterion $filter): Content
+    {
+        $contentId = $filter->value[0];
+        if ($filter instanceof Criterion\ContentId && isset($this->loadedItems[$contentId])) {
+            return $this->loadedItems[$contentId];
+        }
+
+        $item = $this->innerLoader->findSingle($filter);
+        $this->loadedItems[$item->id] = $item;
+
+        return $item;
+    }
+
+    /**
+     * Counts the results of a query.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     *
+     * @return int
+     */
+    public function count(Query $query)
+    {
+        return $this->innerLoader->count($query);
+    }
+}

--- a/src/GraphQL/DataLoader/CachedContentLoader.php
+++ b/src/GraphQL/DataLoader/CachedContentLoader.php
@@ -10,6 +10,9 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
+/**
+ * @internal
+ */
 class CachedContentLoader implements ContentLoader
 {
     /**

--- a/src/GraphQL/DataLoader/CachedContentTypeLoader.php
+++ b/src/GraphQL/DataLoader/CachedContentTypeLoader.php
@@ -8,6 +8,9 @@ namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
+/**
+ * @internal
+ */
 class CachedContentTypeLoader implements ContentTypeLoader
 {
     /**

--- a/src/GraphQL/DataLoader/CachedContentTypeLoader.php
+++ b/src/GraphQL/DataLoader/CachedContentTypeLoader.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+
+class CachedContentTypeLoader implements ContentTypeLoader
+{
+    /**
+     * @var ContentTypeLoader
+     */
+    private $innerLoader;
+
+    /**
+     * @var ContentType[]
+     */
+    private $loadedItems = [];
+
+    public function __construct(ContentTypeLoader $innerLoader)
+    {
+        $this->innerLoader = $innerLoader;
+    }
+
+    public function load($contentTypeId): ContentType
+    {
+        if (!isset($this->loadedItems[$contentTypeId])) {
+            $this->loadedItems[$contentTypeId] = $this->innerLoader->load($contentTypeId);
+        }
+
+        return $this->loadedItems[$contentTypeId];
+    }
+
+    public function loadByIdentifier($identifier): ContentType
+    {
+        $contentType = $this->innerLoader->loadByIdentifier($identifier);
+
+        if (!isset($this->innerLoader[$contentType->id])) {
+            $this->innerLoader[$contentType->id] = $contentType;
+        }
+
+        return $contentType;
+    }
+}

--- a/src/GraphQL/DataLoader/ContentLoader.php
+++ b/src/GraphQL/DataLoader/ContentLoader.php
@@ -10,6 +10,9 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
+/**
+ * @internal
+ */
 interface ContentLoader
 {
     /**

--- a/src/GraphQL/DataLoader/ContentLoader.php
+++ b/src/GraphQL/DataLoader/ContentLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+interface ContentLoader
+{
+    /**
+     * Loads a list of content items given a Query Criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     */
+    public function find(Query $query): array;
+
+    /**
+     * Loads a single content item given a Query Criterion.
+     *
+     * @param Criterion $criterion A Query Criterion.
+     *        Use Criterion\ContentId, Criterion\RemoteId or Criterion\LocationId for basic loading.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    public function findSingle(Criterion $criterion): Content;
+
+    /**
+     * Counts the results of a query.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     *
+     * @return int
+     */
+    public function count(Query $query);
+}

--- a/src/GraphQL/DataLoader/ContentTypeLoader.php
+++ b/src/GraphQL/DataLoader/ContentTypeLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+
+interface ContentTypeLoader
+{
+    public function load($contentTypeId): ContentType;
+
+    public function loadByIdentifier($identifier): ContentType;
+}

--- a/src/GraphQL/DataLoader/ContentTypeLoader.php
+++ b/src/GraphQL/DataLoader/ContentTypeLoader.php
@@ -8,6 +8,9 @@ namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
+/**
+ * @internal
+ */
 interface ContentTypeLoader
 {
     public function load($contentTypeId): ContentType;

--- a/src/GraphQL/DataLoader/Exception/NotFoundException.php
+++ b/src/GraphQL/DataLoader/Exception/NotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\Exception;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException as NotFoundApiException;
+
+class NotFoundException extends NotFoundApiException
+{
+}

--- a/src/GraphQL/DataLoader/RepositoryContentTypeLoader.php
+++ b/src/GraphQL/DataLoader/RepositoryContentTypeLoader.php
@@ -9,6 +9,9 @@ namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
+/**
+ * @internal
+ */
 class RepositoryContentTypeLoader implements ContentTypeLoader
 {
     /**

--- a/src/GraphQL/DataLoader/RepositoryContentTypeLoader.php
+++ b/src/GraphQL/DataLoader/RepositoryContentTypeLoader.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+
+class RepositoryContentTypeLoader implements ContentTypeLoader
+{
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    public function load($contentTypeId): ContentType
+    {
+        return $this->contentTypeService->loadContentType($contentTypeId);
+    }
+
+    public function loadByIdentifier($identifier): ContentType
+    {
+        return $this->contentTypeService->loadContentTypeByIdentifier($identifier);
+    }
+}

--- a/src/GraphQL/DataLoader/SearchContentLoader.php
+++ b/src/GraphQL/DataLoader/SearchContentLoader.php
@@ -14,6 +14,9 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
+/**
+ * @internal
+ */
 class SearchContentLoader implements ContentLoader
 {
     /**

--- a/src/GraphQL/DataLoader/SearchContentLoader.php
+++ b/src/GraphQL/DataLoader/SearchContentLoader.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
+
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\Exception\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions as ApiException;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+class SearchContentLoader implements ContentLoader
+{
+    /**
+     * @var SearchService
+     */
+    private $searchService;
+
+    public function __construct(SearchService $searchService)
+    {
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * Loads a list of content items given a Query Criterion.
+     *
+     * @param Query $query A Query Criterion. To use multiple criteria, group them with a LogicalAnd.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function find(Query $query): array
+    {
+        return array_map(
+            function (SearchHit $searchHit) {
+                return $searchHit->valueObject;
+            },
+            $this->searchService->findContent($query)->searchHits
+        );
+    }
+
+    /**
+     * Loads a single content item given a Query Criterion.
+     *
+     * @param Criterion $filter A Query Criterion. Use Criterion\ContentId, Criterion\RemoteId or Criterion\LocationId for basic loading.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     *
+     * @throws NotFoundException
+     */
+    public function findSingle(Criterion $filter): Content
+    {
+        try {
+            return $this->searchService->findSingle($filter);
+        } catch (ApiException\InvalidArgumentException $e) {
+        } catch (ApiException\NotFoundException $e) {
+            throw new NotFoundException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Counts the results of a query.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     *
+     * @return int
+     *
+     * @throws NotFoundException
+     */
+    public function count(Query $query)
+    {
+        $countQuery = clone $query;
+        $countQuery->limit = 0;
+        $countQuery->offset = 0;
+
+        try {
+            return $this->searchService->findContent($countQuery)->totalCount;
+        } catch (ApiException\InvalidArgumentException $e) {
+            throw new NotFoundException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/GraphQL/Resolver/ContentResolver.php
+++ b/src/GraphQL/Resolver/ContentResolver.php
@@ -5,16 +5,12 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
-use EzSystems\EzPlatformGraphQL\GraphQL\Value\ContentFieldValue;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
-use Overblog\GraphQLBundle\Resolver\TypeResolver;
 
 class ContentResolver
 {

--- a/src/GraphQL/Resolver/ImageAssetFieldResolver.php
+++ b/src/GraphQL/Resolver/ImageAssetFieldResolver.php
@@ -1,7 +1,8 @@
 <?php
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
-use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader;
 use eZ\Publish\Core\FieldType\ImageAsset\AssetMapper;
 use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
 
@@ -12,25 +13,25 @@ class ImageAssetFieldResolver
      */
     private $domainContentResolver;
     /**
-     * @var ContentService
+     * @var ContentLoader
      */
-    private $contentService;
+    private $contentLoader;
     /**
      * @var AssetMapper
      */
     private $assetMapper;
 
-    public function __construct(ContentService $contentService, DomainContentResolver $domainContentResolver, AssetMapper $assetMapper)
+    public function __construct(ContentLoader $contentLoader, DomainContentResolver $domainContentResolver, AssetMapper $assetMapper)
     {
         $this->domainContentResolver = $domainContentResolver;
-        $this->contentService = $contentService;
+        $this->contentLoader = $contentLoader;
         $this->assetMapper = $assetMapper;
     }
 
     public function resolveDomainImageAssetFieldValue(Field $field)
     {
         $assetField = $this->assetMapper->getAssetField(
-            $this->contentService->loadContent($field->value->destinationContentId)
+            $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId))
         );
 
         if (empty($assetField->value->alternativeText)) {

--- a/src/GraphQL/Resolver/ImageFieldResolver.php
+++ b/src/GraphQL/Resolver/ImageFieldResolver.php
@@ -6,8 +6,10 @@
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\FieldType;
 use eZ\Publish\SPI\Variation\VariationHandler;
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader;
 use Overblog\GraphQLBundle\Error\UserError;
 use eZ\Publish\Core\FieldType\Image\Value as ImageFieldValue;
 
@@ -30,10 +32,15 @@ class ImageFieldResolver
      * @var FieldType\Image\Type
      */
     private $fieldType;
+    /**
+     * @var ContentLoader
+     */
+    private $contentLoader;
 
     public function __construct(
         FieldType\Image\Type $imageFieldType,
         VariationHandler $variationHandler,
+        ContentLoader $contentLoader,
         ContentService $contentService,
         array $variations
     )
@@ -42,6 +49,7 @@ class ImageFieldResolver
         $this->contentService = $contentService;
         $this->variations = $variations;
         $this->fieldType = $imageFieldType;
+        $this->contentLoader = $contentLoader;
     }
 
     public function resolveImageVariations(ImageFieldValue $fieldValue, $args)
@@ -79,9 +87,9 @@ class ImageFieldResolver
      */
     protected function getImageField(ImageFieldValue $fieldValue): array
     {
-        list($contentId, $fieldId, $versionNumber) = $this->decomposeImageId($fieldValue);
+        list($contentId, $fieldId) = $this->decomposeImageId($fieldValue);
 
-        $content = $this->contentService->loadContent($contentId, [], $versionNumber);
+        $content = $this->contentLoader->findSingle(new Criterion\ContentId($contentId));
 
         $fieldFound = false;
         /** @var $field \eZ\Publish\API\Repository\Values\Content\Field */

--- a/src/Resources/config/graphql/DomainContent.types.yml
+++ b/src/Resources/config/graphql/DomainContent.types.yml
@@ -42,28 +42,28 @@ AbstractDomainContent:
             _type:
                 description: "The item's Content type"
                 type: ContentType
-                resolve: '@=resolver("ContentTypeById", [value.contentTypeId])'
+                resolve: '@=resolver("ContentTypeById", [value.contentInfo.contentTypeId])'
             _content:
                 description: 'Underlying content info item'
                 type: Content
-                resolve: '@=value'
+                resolve: '@=value.contentInfo'
                 deprecationReason: "Renamed to _info"
             _info:
                 description: 'Underlying content info item'
                 type: Content
-                resolve: '@=value'
+                resolve: '@=value.contentInfo'
             _location:
                 description: 'Main location'
                 type: Location
-                resolve: '@=resolver("LocationById", [value.mainLocationId])'
+                resolve: '@=resolver("LocationById", [value.contentInfo.mainLocationId])'
             _allLocations:
                 description: 'All the locations'
                 type: '[Location]'
-                resolve: '@=resolver("LocationsByContentId", [value.id])'
+                resolve: '@=resolver("LocationsByContentId", [value.contentInfo.id])'
             _name:
                 description: "The content item's name, in the prioritized language(s), based on the object name pattern"
                 type: String
-                resolve: "@=resolver('ContentName', [value])"
+                resolve: "@=value.getName()"
             _url:
                 description: "The content item's url alias, based on the main location."
                 type: String

--- a/src/Resources/config/resolvers.yml
+++ b/src/Resources/config/resolvers.yml
@@ -35,7 +35,6 @@ services:
             - { name: overblog_graphql.resolver, alias: "DomainContentType", method: "resolveDomainContentType" }
             - { name: overblog_graphql.resolver, alias: "DomainContentItem", method: "resolveDomainContentItem" }
             - { name: overblog_graphql.resolver, alias: "DomainRelationFieldValue", method: "resolveDomainRelationFieldValue" }
-            - { name: overblog_graphql.resolver, alias: "ContentName", method: "resolveContentName" }
             - { name: overblog_graphql.resolver, alias: "MainUrlAlias", method: "resolveMainUrlAlias" }
         arguments:
             $repository: "@ezpublish.siteaccessaware.repository"

--- a/src/Resources/config/services/data_loaders.yml
+++ b/src/Resources/config/services/data_loaders.yml
@@ -1,0 +1,31 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+        public: false
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\:
+        resource: ../../GraphQL/DataLoader
+
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\SearchContentLoader:
+        arguments:
+            $searchService: '@ezpublish.siteaccessaware.service.search'
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\CachedContentLoader:
+        arguments:
+            - '@EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\SearchContentLoader'
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader: '@EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\CachedContentLoader'
+
+
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\RepositoryContentTypeLoader:
+        arguments:
+            $contentTypeService: '@ezpublish.siteaccessaware.service.content_type'
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\CachedContentTypeLoader:
+        arguments:
+            - '@EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\RepositoryContentTypeLoader'
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentTypeLoader: '@EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\CachedContentTypeLoader'


### PR DESCRIPTION
The `CachedContentLoader` stores loader Content items to avoid reloading them from the Repository.

The execution time is [down 17%](https://blackfire.io/profiles/compare/bea2b8de-6565-4e7d-9231-d04dd33c9946/graph) on the following query, with way fewer DB/SPI cache* queries:
```
{
  media {
    images(sortBy: [_dateModified, _desc]) {
      _url
      name
      image {
        uri
      }
      caption { html5 }
    }
  }
}
```

* In regards to SPI cache, on a simple query of two fields from 3 articles, cache calls are down from ~500 to ~200. With a redis based cache, the impact is fairly important.

### TODO
- [ ] Take mutations into account. Clear all in-memory cache ?