### PR TITLE
Natural filtering

### DIFF
--- a/src/DependencyInjection/Factory/SearchFeaturesFactory.php
+++ b/src/DependencyInjection/Factory/SearchFeaturesFactory.php
@@ -1,0 +1,34 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Factory;
+
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+
+class SearchFeaturesFactory
+{
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
+     */
+    private $configurationProvider;
+
+    /**
+     * @var \EzSystems\EzPlatformGraphQL\Search\SearchFeatures[]
+     */
+    private $searchFeatures = [];
+
+    public function __construct(RepositoryConfigurationProvider $configurationProvider, array $searchFeatures)
+    {
+        $this->configurationProvider = $configurationProvider;
+        $this->searchFeatures = $searchFeatures;
+    }
+
+    public function build()
+    {
+        $searchEngine = $this->configurationProvider->getRepositoryConfig()['search']['engine'];
+
+        if (isset($this->searchFeatures[$searchEngine])) {
+            return $this->searchFeatures[$searchEngine];
+        } else {
+            throw new \InvalidArgumentException("Search engine not found");
+        }
+    }
+}

--- a/src/GraphQL/InputMapper/SearchQueryMapper.php
+++ b/src/GraphQL/InputMapper/SearchQueryMapper.php
@@ -9,6 +9,7 @@
 namespace EzSystems\EzPlatformGraphQL\GraphQL\InputMapper;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
+use GraphQL\Error\UserError;
 use InvalidArgumentException;
 
 class SearchQueryMapper
@@ -29,21 +30,20 @@ class SearchQueryMapper
             $criteria[] = new Query\Criterion\FullText($inputArray['Text']);
         }
 
-        if (isset($inputArray['Field']))
-        {
-            if (isset($inputArray['Field']['target'])) {
-                $criteria[] = $this->mapInputToFieldCriterion($inputArray['Field']);
-            } else {
-                $criteria = array_merge(
-                    $criteria,
-                    array_map(
-                        function($input) {
-                            return $this->mapInputToFieldCriterion($input);
-                        },
-                        $inputArray['Field']
-                    )
-                );
-            }
+        if (isset($inputArray['Field'])) {
+            $inputArray['Fields'] = [$inputArray['Field']];
+        }
+
+        if (isset($inputArray['Fields'])) {
+            $criteria = array_merge(
+                $criteria,
+                array_map(
+                    function($input) {
+                        return $this->mapInputToFieldCriterion($input);
+                    },
+                    $inputArray['Fields']
+                )
+            );
         }
 
         $criteria = array_merge($criteria, $this->mapDateMetadata($inputArray, 'Modified'));

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,3 +20,20 @@ services:
             - { name: "overblog_graphql.mutation", alias: "DeleteSection", method: "deleteSection" }
 
     EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQueryMapper: ~
+
+    EzSystems\EzPlatformGraphQL\DependencyInjection\Factory\SearchFeaturesFactory:
+        arguments:
+            $configurationProvider: '@ezpublish.api.repository_configuration_provider'
+            $searchFeatures:
+                solr: '@EzSystems\EzPlatformGraphQL\Search\SolrSearchFeatures'
+                legacy: '@EzSystems\EzPlatformGraphQL\Search\LegacySearchFeatures'
+
+    EzSystems\EzPlatformGraphQL\Search\SearchFeatures:
+        factory: ['@EzSystems\EzPlatformGraphQL\DependencyInjection\Factory\SearchFeaturesFactory', build]
+
+    EzSystems\EzPlatformGraphQL\Search\LegacySearchFeatures:
+        arguments:
+            $converterRegistry: '@ezpublish.persistence.legacy.field_value_converter.registry'
+
+    EzSystems\EzPlatformGraphQL\Search\SolrSearchFeatures: ~
+

--- a/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToCollectionFilters.php
+++ b/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToCollectionFilters.php
@@ -1,0 +1,87 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\FieldDefinition;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
+use EzSystems\EzPlatformGraphQL\Schema\Worker;
+use EzSystems\EzPlatformGraphQL\Search\SearchFeatures;
+
+/**
+ * Adds the field definition, if it is searchable, as a filter on the type's collection.
+ */
+class AddFieldDefinitionToCollectionFilters extends BaseWorker implements Worker
+{
+    /**
+     * @var SearchFeatures
+     */
+    private $searchFeatures;
+
+    public function __construct(SearchFeatures $searchFeatures)
+    {
+        $this->searchFeatures = $searchFeatures;
+    }
+
+    public function work(Builder $schema, array $args)
+    {
+        $domainGroupName = $this->getNameHelper()->domainGroupName($args['ContentTypeGroup']);
+        $domainContentCollectionField = $this->getNameHelper()->domainContentCollectionField($args['ContentType']);
+        $fieldDefinitionField = $this->getNameHelper()->fieldDefinitionField($args['FieldDefinition']);
+
+        $schema->addFieldToType(
+            $domainGroupName,
+            new Builder\Input\Field(
+                $domainContentCollectionField,
+                $this->getFilterType($args['FieldDefinition']),
+                ['description' => 'Filter content based on the ' . $args['FieldDefinition']->identifier . ' field']
+            )
+        );
+    }
+
+    public function canWork(Builder $schema, array $args)
+    {
+        return
+            isset($args['FieldDefinition'])
+            && $args['FieldDefinition'] instanceof FieldDefinition
+            & isset($args['ContentType'])
+            && $args['ContentType'] instanceof ContentType
+            && $this->searchFeatures->supportsFieldCriterion($args['FieldDefinition']);
+    }
+
+    /**
+     * @param ContentType $contentType
+     * @return string
+     */
+    protected function getDomainContentName(ContentType $contentType): string
+    {
+        return $this->getNameHelper()->domainContentName($contentType);
+    }
+
+    /**
+     * @param FieldDefinition $fieldDefinition
+     * @return string
+     */
+    protected function getFieldDefinitionField(FieldDefinition $fieldDefinition): string
+    {
+        return $this->getNameHelper()->fieldDefinitionField($fieldDefinition);
+    }
+
+    private function isSearchable(FieldDefinition $fieldDefinition): bool
+    {
+        return $fieldDefinition->isSearchable
+            // should only be verified if legacy is the current search engine
+            && $this->converterRegistry->getConverter($fieldDefinition->fieldTypeIdentifier)->getIndexColumn() !== false;
+    }
+
+    private function getFilterType(FieldDefinition $fieldDefinition)
+    {
+        switch ($fieldDefinition->fieldTypeIdentifier)
+        {
+            case 'ezboolean':
+                return 'Boolean';
+            default:
+                return 'String';
+        }
+    }
+}

--- a/src/Search/LegacySearchFeatures.php
+++ b/src/Search/LegacySearchFeatures.php
@@ -1,0 +1,23 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\Search;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+
+class LegacySearchFeatures implements SearchFeatures
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
+     */
+    private $converterRegistry;
+
+    public function __construct(ConverterRegistry $converterRegistry)
+    {
+        $this->converterRegistry = $converterRegistry;
+    }
+
+    public function supportsFieldCriterion(FieldDefinition $fieldDefinition)
+    {
+        return $this->converterRegistry->getConverter($fieldDefinition->fieldTypeIdentifier)->getIndexColumn() !== false;
+    }
+}

--- a/src/Search/SearchFeatures.php
+++ b/src/Search/SearchFeatures.php
@@ -1,0 +1,16 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\Search;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+interface SearchFeatures
+{
+    /**
+     * Tests if search supports field filtering on $fieldDefinition.
+     *
+     * @param FieldDefinition $fieldDefinition
+     *
+     * @return bool
+     */
+    public function supportsFieldCriterion(FieldDefinition $fieldDefinition);
+}

--- a/src/Search/SolrSearchFeatures.php
+++ b/src/Search/SolrSearchFeatures.php
@@ -1,0 +1,12 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\Search;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+class SolrSearchFeatures implements SearchFeatures
+{
+    public function supportsFieldCriterion(FieldDefinition $fieldDefinition)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
The collection field for a type (`articles`, `blogPosts`) will expose an argument
for each searchable field:

```
{
  media {
    images(name: "~norway") {
      _name
    }
  }
  content {
    products(price: "> 20", gluten: false) {
      _name
    }
  }
}
```

Supported operators (as first characters of the string): ~ (like, with automatic wildcards), <, >, <=, >=).

### TODO
- [ ] Add syntax for `not` (`!~norway`)
- [ ] Accept array of values arguments where at least one value has an operator as a OR.
- [ ] Handle date fields (`publicationDate: "< 2018/11/10"`)
- [ ] Refactor fields filters processing, and ideally unit test it.
- [x] Figure out what's "searchable" when the LSE is used. It is actually detected when converting the criteria using the LegacyConverter's `getIndexColumn()` method, that returns `false` for these fields. It may have to be taken into account at schema generation's time, but the schema will then depend on the environment / search engine.
- [ ] Reintroduce non-field filters (fulltext, parent location...), probably prefixed with `_`
- [ ] Add fields to `sortBy` as well
