### PR TITLE
Relay connections support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # eZ Platform GraphQL Bundle
 
-This Symfony bundle adds a GraphQL server to eZ Platform, the Open Source CMS. It exposes two endpoints.
+This Symfony bundle adds a GraphQL server to eZ Platform, the Open Source CMS.
 
-## The domain schema: `/graphql`
+## The schema: `/graphql`
 `https://<host>/graphql`
 
-A graph of the repository's domain. It exposes the domain modelled using the repository,
+It first and foremost exposes the domain modelled using the repository,
 based on  content types groups, content types and fields definitions. Use it to implement
 apps or sites dedicated to a given repository structure.
 
 Example: an eZ Platform site.
 
-**Warning: this feature requires extra configuration steps. See the [Domain Schema documentation](doc/domain_schema.md).**
+**Warning: this feature requires specific setup steps. See the [Domain Schema documentation](doc/domain_schema.md).**
 
-## The repository schema: `/graphql/repository`
-`https://<host>/graphql/repository`
-
-A graph of the repository's Public API. It exposes value objects from the repository:
-content, location, field, url alias...
+In addition to the schema based on the content model, the repository's Public API is also available under `_repository`.
+It exposes content, location, field, url alias...
 It is recommended for admin like applications, not limited to a particular repository.
 
 Example: an eZ Platform Admin UI extension.

--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,5 @@
   Dedicated ContentType objects would be instances of their ContentType, and provide
   direct access to their fields.
   `ArticleContent` would have `title`, `intro`, `body` and `image` fields.
+- Fix lists by adding the `edges {cursor node}` structure specified by Relay
+  https://facebook.github.io/relay/graphql/connections.htm

--- a/spec/EzSystems/EzPlatformGraphQL/GraphQL/Resolver/DomainContentResolverSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/GraphQL/Resolver/DomainContentResolverSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQueryMapper;
 use EzSystems\EzPlatformGraphQL\GraphQL\Resolver\DomainContentResolver;
 use eZ\Publish\API\Repository\Repository;

--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentType/AddContentOfTypeConnectionToDomainGroupSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentType/AddContentOfTypeConnectionToDomainGroupSpec.php
@@ -4,6 +4,7 @@ namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentT
 
 use EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType\AddContentOfTypeConnectionToDomainGroup;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType\AddDomainContentCollectionToDomainGroup;
 use spec\EzSystems\EzPlatformGraphQL\Tools\ContentTypeArgument;
 use spec\EzSystems\EzPlatformGraphQL\Tools\ContentTypeGroupArgument;
@@ -12,10 +13,10 @@ use spec\EzSystems\EzPlatformGraphQL\Tools\FieldArgument;
 use spec\EzSystems\EzPlatformGraphQL\Tools\TypeArgument;
 use Prophecy\Argument;
 
-class AddDomainContentCollectionToDomainGroupSpec extends ContentTypeWorkerBehavior
+class AddContentOfTypeConnectionToDomainGroupSpec extends ContentTypeWorkerBehavior
 {
     const GROUP_TYPE = 'DomainGroupTestGroup';
-    const TYPE_TYPE = 'TestTypeContent';
+    const TYPE_TYPE = 'TestTypeContentConnection';
     const COLLECTION_FIELD = 'testTypes';
 
     function let(NameHelper $nameHelper)
@@ -31,13 +32,13 @@ class AddDomainContentCollectionToDomainGroupSpec extends ContentTypeWorkerBehav
             ->willReturn(self::COLLECTION_FIELD);
 
         $nameHelper
-            ->domainContentName(ContentTypeArgument::withIdentifier(self::TYPE_IDENTIFIER))
+            ->domainContentConnection(ContentTypeArgument::withIdentifier(self::TYPE_IDENTIFIER))
             ->willReturn(self::TYPE_TYPE);
     }
 
     function it_is_initializable()
     {
-        $this->shouldHaveType(AddDomainContentCollectionToDomainGroup::class);
+        $this->shouldHaveType(AddContentOfTypeConnectionToDomainGroup::class);
     }
 
     function it_can_not_work_if_args_do_not_include_a_ContentTypeGroup(SchemaBuilder $schema)
@@ -65,9 +66,9 @@ class AddDomainContentCollectionToDomainGroupSpec extends ContentTypeWorkerBehav
                 self::GROUP_TYPE,
                 Argument::allOf(
                     FieldArgument::hasName(self::COLLECTION_FIELD),
-                    FieldArgument::hasType('[' . self::TYPE_TYPE . ']'),
+                    FieldArgument::hasType(self::TYPE_TYPE),
                     FieldArgument::hasDescription(self::TYPE_DESCRIPTION),
-                    FieldArgument::withResolver('DomainContentItemsByTypeIdentifier')
+                    FieldArgument::withResolver('SearchContentOfTypeAsConnection')
                 )
             )
             ->shouldBeCalled();

--- a/src/GraphQL/InputMapper/SearchQueryMapper.php
+++ b/src/GraphQL/InputMapper/SearchQueryMapper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: bdunogier
- * Date: 21/09/2018
- * Time: 16:50
- */
-
 namespace EzSystems\EzPlatformGraphQL\GraphQL\InputMapper;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -14,11 +7,18 @@ use InvalidArgumentException;
 class SearchQueryMapper
 {
     /**
+     * @param array $inputArray
      * @return \eZ\Publish\API\Repository\Values\Content\Query
      */
     public function mapInputToQuery(array $inputArray)
     {
         $query = new Query();
+        if (isset($inputArray['offset'])) {
+            $query->offset = $inputArray['offset'];
+        }
+        if (isset($inputArray['limit'])) {
+            $query->limit = $inputArray['limit'];
+        }
         $criteria = [];
 
         if (isset($inputArray['ContentTypeIdentifier'])) {

--- a/src/GraphQL/Relay/DomainConnectionBuilder.php
+++ b/src/GraphQL/Relay/DomainConnectionBuilder.php
@@ -1,0 +1,9 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
+
+use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+
+class DomainConnectionBuilder extends ConnectionBuilder
+{
+    const PREFIX = 'DomainContent:';
+}

--- a/src/GraphQL/Relay/NodeResolver.php
+++ b/src/GraphQL/Relay/NodeResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
+use Overblog\GraphQLBundle\Relay\Node\GlobalId;
+use Overblog\GraphQLBundle\Resolver\TypeResolver;
+
+class NodeResolver
+{
+    /**
+     * @var ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var TypeResolver
+     */
+    private $typeResolver;
+
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var NameHelper
+     */
+    private $nameHelper;
+
+    public function __construct(ContentService $contentService, TypeResolver $typeResolver, ContentTypeService $contentTypeService, NameHelper $nameHelper)
+    {
+        $this->contentService = $contentService;
+        $this->typeResolver = $typeResolver;
+        $this->contentTypeService = $contentTypeService;
+        $this->nameHelper = $nameHelper;
+    }
+
+    /**
+     * @param $globalId
+     *
+     * @return null|\eZ\Publish\API\Repository\Values\Content\ContentInfo
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function resolveNode($globalId)
+    {
+        $params = GlobalId::fromGlobalId($globalId);
+
+        if (in_array($params['type'], ['Content', 'DomainContent'])) {
+            return $this->contentService->loadContentInfo($params['id']);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param $object
+     *
+     * @return \GraphQL\Type\Definition\Type
+     */
+    public function resolveType($object)
+    {
+        if ($object instanceof ContentInfo) {
+            return $this->typeResolver->resolve(
+                $this->nameHelper->domainContentName(
+                    $this->contentTypeService->loadContentType($object->contentTypeId)
+                )
+            );
+        }
+    }
+}

--- a/src/GraphQL/Relay/SearchResolver.php
+++ b/src/GraphQL/Relay/SearchResolver.php
@@ -1,0 +1,70 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
+use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+
+class SearchResolver
+{
+    /**
+     * @var SearchService
+     */
+    private $searchService;
+
+    public function __construct(SearchService $searchService)
+    {
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * @param $args
+     * @return Connection
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function searchContent($args)
+    {
+        $queryArg = $args['query'];
+
+        $query = new Query();
+        $criteria = [];
+
+        if (isset($queryArg['ContentTypeIdentifier'])) {
+            $criteria[] = new Query\Criterion\ContentTypeIdentifier($queryArg['ContentTypeIdentifier']);
+        }
+
+        if (isset($queryArg['Text'])) {
+            foreach ($queryArg['Text'] as $text) {
+                $criteria[] = new Query\Criterion\FullText($text);
+            }
+        }
+
+        if (count($criteria) === 0) {
+            return null;
+        }
+        $query->filter = count($criteria) > 1 ? new Query\Criterion\LogicalAnd($criteria) : $criteria[0];
+        $searchResult = $this->searchService->findContentInfo($query);
+
+        $contentItems = array_map(
+            function (SearchHit $hit) {
+                return $hit->valueObject;
+            },
+            $searchResult->searchHits
+        );
+
+        $connection = ConnectionBuilder::connectionFromArraySlice(
+            $contentItems,
+            $args,
+            [
+                'sliceStart' => 0,
+                'arrayLength' => $searchResult->totalCount,
+            ]
+        );
+        $connection->sliceSize = count($contentItems);
+
+        return $connection;
+    }
+}

--- a/src/Resources/config/graphql/Content.types.yml
+++ b/src/Resources/config/graphql/Content.types.yml
@@ -1,12 +1,13 @@
 Content:
     type: object
     config:
+        interfaces: [Node]
         description: "An eZ Platform repository ContentInfo."
         fields:
             id:
-                type: "Int!"
+                type: "ID!"
+                builder: Relay::GlobalId
                 description: "The Content item's unique ID."
-                resolve:
             contentTypeId:
                 type: "Int!"
                 description: "The Content Type ID of the Content item."
@@ -97,6 +98,7 @@ Content:
                 type: "[ContentRelation]"
                 description: "Relations to this Content"
                 resolve: "@=resolver('ContentReverseRelations', [value])"
+
 ContentRelation:
     type: "object"
     config:

--- a/src/Resources/config/graphql/DomainContent.types.yml
+++ b/src/Resources/config/graphql/DomainContent.types.yml
@@ -36,6 +36,8 @@ AbstractDomainContent:
             id:
                 type: "ID!"
                 builder: Relay::GlobalId
+                builderConfig:
+                    typeName: DomainContent
                 description: "The Content item's unique ID."
             _type:
                 description: "The item's Content type"
@@ -95,3 +97,14 @@ BaseDomainContentType:
             _info:
                 type: ContentType
                 resolve: "@=value"
+
+DomainContentByIdentifierConnection:
+    type: relay-connection
+    config:
+        connectionFields:
+            sliceSize:
+                type: Int!
+            orderBy:
+                # @todo make an enum or object
+                # @todo generate
+                type: String

--- a/src/Resources/config/graphql/Node.types.yml
+++ b/src/Resources/config/graphql/Node.types.yml
@@ -1,0 +1,7 @@
+# interface Node {
+#   id: ID!
+# }
+Node:
+    type: relay-node
+    config:
+        resolveType: '@=resolver("node_type", [value])'

--- a/src/Resources/config/graphql/Platform.types.yml
+++ b/src/Resources/config/graphql/Platform.types.yml
@@ -6,3 +6,8 @@ Platform:
                 type: Repository
                 resolve: { }
                 description: "eZ Platform repository API"
+            node:
+                builder: Relay::Node
+                builderConfig:
+                    nodeInterfaceType: Node
+                    idFetcher: '@=resolver("node", [value])'

--- a/src/Resources/config/graphql/Repository.types.yml
+++ b/src/Resources/config/graphql/Repository.types.yml
@@ -68,10 +68,10 @@ Repository:
                     groupIdentifier:
                         type: "String"
                 resolve: "@=resolver('ContentTypesFromGroup', [args])"
-
             searchContent:
                 type: "[Content]"
                 args:
                     query:
                         type: "ContentSearchQuery!"
                 resolve: "@=resolver('SearchContent', [args])"
+

--- a/src/Resources/config/graphql/Search.types.yml
+++ b/src/Resources/config/graphql/Search.types.yml
@@ -23,6 +23,8 @@ ContentSearchQuery:
             Field:
                 type: "[FieldCriterionInput]"
                 description: "Field filter"
+            SortBy:
+                type: "SortByOptions"
 
 FieldCriterionInput:
      type: "input-object"

--- a/src/Resources/config/resolvers.yml
+++ b/src/Resources/config/resolvers.yml
@@ -92,6 +92,7 @@ services:
     EzSystems\EzPlatformGraphQL\GraphQL\Resolver\SearchResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "SearchContent", method: "searchContent" }
+            - { name: overblog_graphql.resolver, alias: "SearchContentOfTypeAsConnection", method: "searchContentOfTypeAsConnection" }
         arguments:
             $searchService: '@ezpublish.siteaccessaware.service.search'
 
@@ -124,3 +125,12 @@ services:
     EzSystems\EzPlatformGraphQL\GraphQL\Resolver\SelectionFieldResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "SelectionFieldValue", method: "resolveSelectionFieldValue"}
+
+    EzSystems\EzPlatformGraphQL\GraphQL\Relay\NodeResolver:
+        tags:
+            - { name: overblog_graphql.resolver, alias: "node", method: "resolveNode" }
+            - { name: overblog_graphql.resolver, alias: "node_type", method: "resolveType" }
+
+    EzSystems\EzPlatformGraphQL\GraphQL\Relay\SearchResolver:
+        tags:
+            - {name: overblog_graphql.resolver, alias: "SearchContentConnection", method: "searchContent"}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,22 +1,14 @@
 services:
-    EzSystems\EzPlatformGraphQL\Command\GeneratePlatformDomainTypesCommand:
+    _defaults:
         autoconfigure: true
         autowire: true
+        public: false
+
+    EzSystems\EzPlatformGraphQL\Command\:
+        resource: '../../Command/*'
         tags:
             -  { name: console.command }
 
-    EzSystems\EzPlatformGraphQL\Command\GeneratePlatformSchemaCommand:
-        autoconfigure: true
-        autowire: true
-        tags:
-            -  { name: console.command }
-
-    bd_ezplatform_graphql.graph.mutation.section:
-        class: EzSystems\EzPlatformGraphQL\GraphQL\Mutation\SectionMutation
-        arguments:
-            - "@ezpublish.api.service.section"
-        tags:
-            - { name: "overblog_graphql.mutation", alias: "CreateSection", method: "createSection" }
-            - { name: "overblog_graphql.mutation", alias: "DeleteSection", method: "deleteSection" }
+    EzSystems\EzPlatformGraphQL\GraphQL\TypeDefinition\ContentTypeMapper: ~
 
     EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQueryMapper: ~

--- a/src/Schema/Builder/Input/Field.php
+++ b/src/Schema/Builder/Input/Field.php
@@ -14,4 +14,5 @@ class Field extends Input
     public $description;
     public $type;
     public $resolve;
+    public $argsBuilder;
 }

--- a/src/Schema/Builder/Input/Type.php
+++ b/src/Schema/Builder/Input/Type.php
@@ -14,4 +14,5 @@ class Type extends Input
     public $type;
     public $inherits = [];
     public $interfaces = [];
+    public $nodeType;
 }

--- a/src/Schema/Builder/SchemaBuilder.php
+++ b/src/Schema/Builder/SchemaBuilder.php
@@ -30,6 +30,9 @@ class SchemaBuilder implements SchemaBuilderInterface
                 [$typeInput->interfaces];
         }
 
+        if (isset($typeInput->nodeType)) {
+            $type['config']['nodeType'] = $typeInput->nodeType;
+        }
         $this->schema[$typeInput->name] = $type;
     }
 
@@ -49,6 +52,9 @@ class SchemaBuilder implements SchemaBuilderInterface
         }
         if (isset($fieldInput->resolve)) {
             $field['resolve'] = $fieldInput->resolve;
+        }
+        if (isset($fieldInput->argsBuilder)) {
+            $field['argsBuilder'] = $fieldInput->argsBuilder;
         }
 
         $this->schema[$type]['config']['fields'][$fieldInput->name] = $field;

--- a/src/Schema/Domain/Content/NameHelper.php
+++ b/src/Schema/Domain/Content/NameHelper.php
@@ -28,6 +28,11 @@ class NameHelper
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'Content';
     }
 
+    public function domainContentConnection($contentType)
+    {
+        return ucfirst($this->toCamelCase($contentType->identifier)) . 'ContentConnection';
+    }
+
     public function domainContentTypeName(ContentType $contentType)
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'ContentType';

--- a/src/Schema/Domain/Content/Worker/ContentType/AddContentOfTypeConnectionToDomainGroup.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/AddContentOfTypeConnectionToDomainGroup.php
@@ -8,7 +8,7 @@ use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 
-class AddDomainContentCollectionToDomainGroup extends BaseWorker implements Worker
+class AddContentOfTypeConnectionToDomainGroup extends BaseWorker implements Worker
 {
     public function work(Builder $schema, array $args)
     {
@@ -16,23 +16,24 @@ class AddDomainContentCollectionToDomainGroup extends BaseWorker implements Work
         $descriptions = $contentType->getDescriptions();
 
         $schema->addFieldToType($this->groupName($args), new Input\Field(
-            $this->typeCollectionField($args),
-            sprintf("[%s]", $this->typeName($args)),
+            $this->connectionField($args),
+            $this->connectionType($args),
             [
                 'description' => isset($descriptions['eng-GB']) ? $descriptions['eng-GB'] : 'No description available',
                 'resolve' => sprintf(
-                    '@=resolver("DomainContentItemsByTypeIdentifier", ["%s", args])',
+                    '@=resolver("SearchContentOfTypeAsConnection", ["%s", args])',
                     $contentType->identifier
-                )
+                ),
+                'argsBuilder' => 'Relay::Connection',
             ]
         ));
 
-        $schema->addArgToField($this->groupName($args), $this->typeCollectionField($args), new Input\Arg(
+        $schema->addArgToField($this->groupName($args), $this->connectionField($args), new Input\Arg(
             'query', 'ContentSearchQuery',
             ['description' => "A Content query used to filter results"]
         ));
 
-        $schema->addArgToField($this->groupName($args), $this->typeCollectionField($args), new Input\Arg(
+        $schema->addArgToField($this->groupName($args), $this->connectionField($args), new Input\Arg(
             'sortBy', '[SortByOptions]',
             ['description' => "A sort clause, or array of clauses. Add _desc after a clause to reverse it"]
         ));
@@ -45,7 +46,7 @@ class AddDomainContentCollectionToDomainGroup extends BaseWorker implements Work
             && $args['ContentType'] instanceof ContentType
             && isset($args['ContentTypeGroup'])
             && $args['ContentTypeGroup'] instanceof ContentTypeGroup
-            && !$schema->hasTypeWithField($this->groupName($args), $this->typeCollectionField($args));
+            && !$schema->hasTypeWithField($this->groupName($args), $this->connectionField($args));
     }
 
     protected function groupName(array $args): string
@@ -53,9 +54,14 @@ class AddDomainContentCollectionToDomainGroup extends BaseWorker implements Work
         return $this->getNameHelper()->domainGroupName($args['ContentTypeGroup']);
     }
 
-    protected function typeCollectionField(array $args): string
+    protected function connectionField(array $args): string
     {
         return $this->getNameHelper()->domainContentCollectionField($args['ContentType']);
+    }
+
+    protected function connectionType(array $args): string
+    {
+        return $this->getNameHelper()->domainContentConnection($args['ContentType']);
     }
 
     protected function typeName($args): string

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContent.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContent.php
@@ -16,7 +16,7 @@ class DefineDomainContent extends BaseWorker implements Worker, GroupProvider
             $this->typeName($args), 'object',
             [
                 'inherits' => 'AbstractDomainContent',
-                'interfaces' => 'DomainContent'
+                'interfaces' => ['DomainContent', 'Node']
             ]
         ));
     }

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentConnection.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentConnection.php
@@ -1,0 +1,40 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
+
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
+use EzSystems\EzPlatformGraphQL\Schema\Worker;
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+
+class DefineDomainContentConnection extends BaseWorker implements Worker
+{
+    public function work(Builder $schema, array $args)
+    {
+        $schema->addType(new Input\Type(
+            $this->connectionTypeName($args),
+            'relay-connection',
+            [
+                'inherits' => 'DomainContentByIdentifierConnection',
+                'nodeType' => $this->typeName($args),
+            ]
+        ));
+    }
+
+    public function canWork(Builder $schema, array $args)
+    {
+        return isset($args['ContentType']) && $args['ContentType'] instanceof ContentType
+               && !$schema->hasType($this->connectionTypeName($args));
+    }
+
+    protected function connectionTypeName(array $args): string
+    {
+        return $this->getNameHelper()->domainContentConnection($args['ContentType']);
+    }
+
+    protected function typeName($args): string
+    {
+        return $this->getNameHelper()->domainContentName($args['ContentType']);
+    }
+}


### PR DESCRIPTION
Changes lists of content items to [Connections](https://facebook.github.io/relay/graphql/connections.htm):

```
{
  content {
    blogPosts(sortBy: DatePublished, last: 5) {
      pageInfo {
        hasNextPage
      }
      edges {
        cursor
        node {
          title
        }
      }
    }
  }
}
```

Allows to implement [pagination](https://facebook.github.io/relay/docs/en/pagination-container.html), as well as individual items refetching.

### TODO
- [x] Fix ID handling: domain content items will return a Global Id, that can not be used for fetching individual items. This needs to be unified
- [x] Verify the impact of globally changing resolution of searches by type identifier to a connection. It has probably broken some stuff (fixed by using a custom resolver for content type search based connections)
- [x] Restore the previous collection worker, disable the service with a mention, and create a new one for _connections_