### PR TITLE
EZP-30283: Implement fetching Object States in GraphQL

### DIFF
--- a/src/GraphQL/Resolver/ObjectStateGroupResolver.php
+++ b/src/GraphQL/Resolver/ObjectStateGroupResolver.php
@@ -6,8 +6,10 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\ObjectStateService;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
+use GraphQL\Error\UserError;
 use Overblog\GraphQLBundle\Definition\Argument;
 
 class ObjectStateGroupResolver
@@ -27,12 +29,14 @@ class ObjectStateGroupResolver
      * @param \Overblog\GraphQLBundle\Definition\Argument $args
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function resolveObjectStateGroupById(Argument $args): ObjectStateGroup
     {
-        return $this->objectStateService->loadObjectStateGroup($args['id']);
+        try {
+            return $this->objectStateService->loadObjectStateGroup($args['id']);
+        } catch (NotFoundException $e) {
+            throw new UserError("Object State Group with ID: {$args['id']} was not found.");
+        }
     }
 
     /**

--- a/src/GraphQL/Resolver/ObjectStateGroupResolver.php
+++ b/src/GraphQL/Resolver/ObjectStateGroupResolver.php
@@ -12,9 +12,7 @@ use Overblog\GraphQLBundle\Definition\Argument;
 
 class ObjectStateGroupResolver
 {
-    /**
-     * @var \eZ\Publish\API\Repository\ObjectStateService
-     */
+    /** @var \eZ\Publish\API\Repository\ObjectStateService */
     private $objectStateService;
 
     /**
@@ -26,7 +24,7 @@ class ObjectStateGroupResolver
     }
 
     /**
-     * @param array $args
+     * @param \Overblog\GraphQLBundle\Definition\Argument $args
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      *

--- a/src/GraphQL/Resolver/ObjectStateGroupResolver.php
+++ b/src/GraphQL/Resolver/ObjectStateGroupResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
+
+use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+class ObjectStateGroupResolver
+{
+    /**
+     * @var \eZ\Publish\API\Repository\ObjectStateService
+     */
+    private $objectStateService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ObjectStateService $objectStateService
+     */
+    public function __construct(ObjectStateService $objectStateService)
+    {
+        $this->objectStateService = $objectStateService;
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function resolveObjectStateGroupById(Argument $args): ObjectStateGroup
+    {
+        return $this->objectStateService->loadObjectStateGroup($args['id']);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup[]
+     */
+    public function resolveObjectStateGroups(): array
+    {
+        return $this->objectStateService->loadObjectStateGroups();
+    }
+}

--- a/src/GraphQL/Resolver/ObjectStateResolver.php
+++ b/src/GraphQL/Resolver/ObjectStateResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
+
+use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+class ObjectStateResolver
+{
+    /**
+     * @var \eZ\Publish\API\Repository\ObjectStateService
+     */
+    private $objectStateService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ObjectStateService $objectStateService
+     */
+    public function __construct(ObjectStateService $objectStateService)
+    {
+        $this->objectStateService = $objectStateService;
+    }
+
+    /**
+     * @param \Overblog\GraphQLBundle\Definition\Argument $args
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function resolveObjectStateById(Argument $args): ObjectState
+    {
+        return $this->objectStateService->loadObjectState($args['id']);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
+     */
+    public function resolveObjectStatesByGroup(ObjectStateGroup $objectStateGroup): array
+    {
+        return $this->objectStateService->loadObjectStates($objectStateGroup);
+    }
+
+    /**
+     * @param \Overblog\GraphQLBundle\Definition\Argument $args
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function resolveObjectStatesByGroupId(Argument $args): array
+    {
+        $group = $this->objectStateService->loadObjectStateGroup($args['groupId']);
+
+        return $this->objectStateService->loadObjectStates($group);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $content
+     * @param \Overblog\GraphQLBundle\Definition\Argument $args
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function resolveObjectStateByContentInfo(ContentInfo $content, Argument $args): ObjectState
+    {
+        $group = $this->objectStateService->loadObjectStateGroup($args['groupId']);
+
+        return $this->objectStateService->getContentState($content, $group);
+    }
+}

--- a/src/GraphQL/Resolver/ObjectStateResolver.php
+++ b/src/GraphQL/Resolver/ObjectStateResolver.php
@@ -14,9 +14,7 @@ use Overblog\GraphQLBundle\Definition\Argument;
 
 class ObjectStateResolver
 {
-    /**
-     * @var \eZ\Publish\API\Repository\ObjectStateService
-     */
+    /** @var \eZ\Publish\API\Repository\ObjectStateService */
     private $objectStateService;
 
     /**

--- a/src/GraphQL/Resolver/ObjectStateResolver.php
+++ b/src/GraphQL/Resolver/ObjectStateResolver.php
@@ -6,10 +6,12 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\ObjectStateService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
+use GraphQL\Error\UserError;
 use Overblog\GraphQLBundle\Definition\Argument;
 
 class ObjectStateResolver
@@ -29,12 +31,14 @@ class ObjectStateResolver
      * @param \Overblog\GraphQLBundle\Definition\Argument $args
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function resolveObjectStateById(Argument $args): ObjectState
     {
-        return $this->objectStateService->loadObjectState($args['id']);
+        try {
+            return $this->objectStateService->loadObjectState($args['id']);
+        } catch (NotFoundException $e) {
+            throw new UserError("Object State with ID: {$args['id']} was not found.");
+        }
     }
 
     /**
@@ -51,12 +55,14 @@ class ObjectStateResolver
      * @param \Overblog\GraphQLBundle\Definition\Argument $args
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function resolveObjectStatesByGroupId(Argument $args): array
     {
-        $group = $this->objectStateService->loadObjectStateGroup($args['groupId']);
+        try {
+            $group = $this->objectStateService->loadObjectStateGroup($args['groupId']);
+        } catch (NotFoundException $e) {
+            throw new UserError("Object State Group with ID: {$args['groupId']} was not found.");
+        }
 
         return $this->objectStateService->loadObjectStates($group);
     }

--- a/src/GraphQL/Resolver/ObjectStateResolver.php
+++ b/src/GraphQL/Resolver/ObjectStateResolver.php
@@ -64,17 +64,17 @@ class ObjectStateResolver
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $content
-     * @param \Overblog\GraphQLBundle\Definition\Argument $args
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
      */
-    public function resolveObjectStateByContentInfo(ContentInfo $content, Argument $args): ObjectState
+    public function resolveObjectStateByContentInfo(ContentInfo $contentInfo): array
     {
-        $group = $this->objectStateService->loadObjectStateGroup($args['groupId']);
+        $objectStates = [];
+        foreach ($this->objectStateService->loadObjectStateGroups() as $group) {
+            $objectStates[] = $this->objectStateService->getContentState($contentInfo, $group);
+        }
 
-        return $this->objectStateService->getContentState($content, $group);
+        return $objectStates;
     }
 }

--- a/src/Resources/config/graphql/Content.types.yml
+++ b/src/Resources/config/graphql/Content.types.yml
@@ -99,13 +99,9 @@ Content:
                 description: "Relations to this Content"
                 resolve: "@=resolver('ContentReverseRelations', [value])"
             states:
-                type: "ObjectState"
-                description: "Object State in given Object State Group."
-                args:
-                    groupId:
-                        type: "Int!"
-                        description: "ID of the Object State Group"
-                resolve: "@=resolver('ObjectStateByContentInfo', [value, args])"
+                type: "[ObjectState]"
+                description: "Content States."
+                resolve: "@=resolver('ObjectStateByContentInfo', [value])"
 
 ContentRelation:
     type: "object"

--- a/src/Resources/config/graphql/Content.types.yml
+++ b/src/Resources/config/graphql/Content.types.yml
@@ -98,6 +98,14 @@ Content:
                 type: "[ContentRelation]"
                 description: "Relations to this Content"
                 resolve: "@=resolver('ContentReverseRelations', [value])"
+            states:
+                type: "ObjectState"
+                description: "Object State in given Object State Group."
+                args:
+                    groupId:
+                        type: "Int!"
+                        description: "ID of the Object State Group"
+                resolve: "@=resolver('ObjectStateByContentInfo', [value, args])"
 
 ContentRelation:
     type: "object"

--- a/src/Resources/config/graphql/ObjectState.types.yml
+++ b/src/Resources/config/graphql/ObjectState.types.yml
@@ -1,0 +1,20 @@
+ObjectState:
+    type: object
+    config:
+        description: "An eZ Platform content object state."
+        fields:
+            id:
+                type: "Int!"
+                description: "The ObjectState's unique ID."
+            identifier:
+                type: "String"
+                description: "The ObjectState's system identifier."
+            priority:
+                type: "Int"
+                description: "The ObjectState's priority used for ordering."
+            languageCodes:
+                type: "[String]"
+                description: "The ObjectStateGroup's language codes."
+            group:
+                type: "ObjectStateGroup"
+                resolve: "@=value.getObjectStateGroup()"

--- a/src/Resources/config/graphql/ObjectStateGroup.types.yml
+++ b/src/Resources/config/graphql/ObjectStateGroup.types.yml
@@ -1,0 +1,21 @@
+ObjectStateGroup:
+    type: object
+    config:
+        description: "An eZ Platform content object state group."
+        fields:
+            id:
+                type: "Int!"
+                description: "The ObjectStateGroup's unique ID."
+            identifier:
+                type: "String"
+                description: "The ObjectStateGroup's system identifier."
+            defaultLanguageCode:
+                type: "String"
+                description: "The ObjectStateGroup's default language code."
+            languageCodes:
+                type: "[String]"
+                description: "The ObjectStateGroup's language codes."
+            states:
+                type: "[ObjectState]"
+                description: "List of ObjectStates under ObjectStateGroup."
+                resolve: "@=resolver('ObjectStatesByGroup', [value])"

--- a/src/Resources/config/graphql/Repository.types.yml
+++ b/src/Resources/config/graphql/Repository.types.yml
@@ -75,3 +75,38 @@ Repository:
                         type: "ContentSearchQuery!"
                 resolve: "@=resolver('SearchContent', [args])"
 
+            #
+            # Object States
+            #
+
+            objectStateGroup:
+                type: 'ObjectStateGroup'
+                description: "Fetches Object State Group by ID."
+                args:
+                    id:
+                        type: "Int"
+                        description: "ID of the Object State Group"
+                resolve: "@=resolver('ObjectStateGroupById', [args])"
+
+            objectStateGroups:
+                type: '[ObjectStateGroup]'
+                description: "Fetches all Object State Groups."
+                resolve: "@=resolver('ObjectStateGroups')"
+
+            objectState:
+                type: 'ObjectState'
+                description: "Fetches Object State by ID."
+                args:
+                    id:
+                        type: "Int"
+                        description: "ID of the Object State"
+                resolve: "@=resolver('ObjectStateById', [args])"
+
+            objectStates:
+                type: '[ObjectState]'
+                description: "Fetches Object States assigned to given Group ID."
+                args:
+                    groupId:
+                        type: "Int"
+                        description: "ID of the ObjectStateGroup"
+                resolve: "@=resolver('ObjectStatesByGroupId', [args])"

--- a/src/Resources/config/resolvers.yml
+++ b/src/Resources/config/resolvers.yml
@@ -134,3 +134,19 @@ services:
     EzSystems\EzPlatformGraphQL\GraphQL\Relay\SearchResolver:
         tags:
             - {name: overblog_graphql.resolver, alias: "SearchContentConnection", method: "searchContent"}
+
+    #
+    # Object States
+    #
+
+    EzSystems\EzPlatformGraphQL\GraphQL\Resolver\ObjectStateGroupResolver:
+        tags:
+            - {name: overblog_graphql.resolver, alias: "ObjectStateGroupById", method: "resolveObjectStateGroupById"}
+            - {name: overblog_graphql.resolver, alias: "ObjectStateGroups", method: "resolveObjectStateGroups"}
+
+    EzSystems\EzPlatformGraphQL\GraphQL\Resolver\ObjectStateResolver:
+        tags:
+            - {name: overblog_graphql.resolver, alias: "ObjectStateById", method: "resolveObjectStateById"}
+            - {name: overblog_graphql.resolver, alias: "ObjectStateByContentInfo", method: "resolveObjectStateByContentInfo"}
+            - {name: overblog_graphql.resolver, alias: "ObjectStatesByGroup", method: "resolveObjectStatesByGroup"}
+            - {name: overblog_graphql.resolver, alias: "ObjectStatesByGroupId", method: "resolveObjectStatesByGroupId"}

--- a/src/Resources/config/resolvers.yml
+++ b/src/Resources/config/resolvers.yml
@@ -140,11 +140,15 @@ services:
     #
 
     EzSystems\EzPlatformGraphQL\GraphQL\Resolver\ObjectStateGroupResolver:
+        arguments:
+            $objectStateService: '@ezpublish.siteaccessaware.service.object_state'
         tags:
             - {name: overblog_graphql.resolver, alias: "ObjectStateGroupById", method: "resolveObjectStateGroupById"}
             - {name: overblog_graphql.resolver, alias: "ObjectStateGroups", method: "resolveObjectStateGroups"}
 
     EzSystems\EzPlatformGraphQL\GraphQL\Resolver\ObjectStateResolver:
+        arguments:
+            $objectStateService: '@ezpublish.siteaccessaware.service.object_state'
         tags:
             - {name: overblog_graphql.resolver, alias: "ObjectStateById", method: "resolveObjectStateById"}
             - {name: overblog_graphql.resolver, alias: "ObjectStateByContentInfo", method: "resolveObjectStateByContentInfo"}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30283

# Description
It adds new fields to `_repository`:
- `objectStateGroup` (args: `id`) - fetches single Object State Group,
- `objectStateGroups` - fetches all Object State Groups,
- `objectState` (args: `id`) - fetches single Object State,
- `objectStates` (args: `groupId`) - fetches Object States assigned to Group with ID = `groupId`.

Also you can access object states from specific group (arg `groupId`) from the content , for example:
```graphql
{
  content {
    about(id: 2) {
      _info {
        states {
          id,
          identifier,
          priority,
          languageCodes,
          group {
            id,
            identifier,
            defaultLanguageCode,
            languageCodes,
            states {
              ...
            }
          }
        }
      }
    }
  }
}
```

# What's missing
I haven't added dynamic fields and types due to time constraints but this can be added in the future. Also mutations are not implemented yet.