### PR TITLE
Removed _info.currentVersion (EZP-30275)

### DIFF
--- a/src/Resources/config/graphql/Content.types.yml
+++ b/src/Resources/config/graphql/Content.types.yml
@@ -42,10 +42,6 @@ Content:
             currentVersionNo:
                 type: "Int"
                 description: "Version number of the published version, or 1 for a newly created draft."
-            currentVersion:
-                type: "Version"
-                description: "The currently published content item version"
-                resolve: "@=resolver('LoadVersion', [value.id, value.currentVersionNo])"
             versions:
                 type: "[Version]"
                 description: "All content versions."


### PR DESCRIPTION
> Fixes [EZP-30275](https://jira.ez.no/browse/EZP-30275)

This was failing because of a missing resolver:

```
someContent {
  _info {
    currentVersion
  }
}
```

Since the current version is exposed at the root of any content, it isn't necessary to have an explicit field for it. This PR removes it, thus fixing the bug.