### PR TITLE
Fixed ezmedia fieldtype width property (EZP-30278)

### DIFF
--- a/src/Resources/config/graphql/Field.types.yml
+++ b/src/Resources/config/graphql/Field.types.yml
@@ -310,7 +310,7 @@ MediaFieldValue:
             width:
                 type: Int
                 description: "Width of the media."
-                resolve: "@=value.widht"
+                resolve: "@=value.width"
     inherits: [BinaryBaseFieldValue, HTMLFieldValue]
 
 PriceFieldValue:


### PR DESCRIPTION
> Fixes [EZP-30278](https://jira.ez.no/browse/EZP-30278)

There was a typo in the field's name, now fixed.

![image](https://user-images.githubusercontent.com/235928/54542962-05f2c480-499d-11e9-884c-b83c5d69d264.png)
