### PR TITLE
Added description field to content types (EZP-30274)

### DIFF
--- a/src/Resources/config/graphql/ContentType.types.yml
+++ b/src/Resources/config/graphql/ContentType.types.yml
@@ -6,9 +6,14 @@ ContentType:
             id:
                 type: "Int!"
                 description: "The Content Type's unique ID."
-            #contentTypeGroups:
-            #    type: "[ContentTypeGroup]"
-            #    description: "ContentType Groups the ContentType is a member of."
+            description:
+                type: "String"
+                description: "The content type's description"
+                args:
+                    languageCode:
+                        type: "String"
+                        defaultValue: ~
+                resolve: "@=value.getDescription(args['languageCode']) ?: ''"
             fieldDefinitions:
                 type: "[FieldDefinition]"
                 description: "The ContentType's Field Definitions."
@@ -25,8 +30,8 @@ ContentType:
                 args:
                     languageCode:
                         type: "String"
-                        defaultValue: "eng-GB"
-                resolve: "@=value.getName(args['languageCode'])"
+                        defaultValue: ~
+                resolve: "@=value.getName(args['languageCode']) ?: ''"
             names:
                 type: "[String]"
                 description: "The Content Type's names in all languages"


### PR DESCRIPTION
> Fixes [EZP-30274](https://jira.ez.no/browse/EZP-30274)

Adds the missing `description` field to content types:

```
{
  content {
    _types {
      article {
        _info {
          description
          french_description: description(languageCode: "fre-FR")
        }
      }
    }
  }
}
```

![image](https://user-images.githubusercontent.com/235928/54596283-97614580-4a34-11e9-8d67-0995bcf10743.png)

### TODO
- [x] Test on v2.5