### PR TITLE
EZP-30325: Generated schema is not being used when vendor packages are symlinked

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterSchemaDirectoryParametersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterSchemaDirectoryParametersPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterSchemaDirectoryParametersPass implements CompilerPassInterface
+{
+    private const APP_SCHEMA_DIR_RELATIVE_PATH = '/config/graphql';
+    private const EZPLATFORM_SCHEMA_DIR_RELATIVE_PATH = '/ezplatform';
+    private const PACKAGE_DIR_RELATIVE_PATH = '/../vendor/ezsystems/ezplatform-graphql';
+    private const PACKAGE_SCHEMA_DIR_RELATIVE_PATH = '/src/Resources/config/graphql';
+    private const FIELS_DEFINITION_FILE_NAME = 'Field.types.yml';
+
+    public function process(ContainerBuilder $container)
+    {
+        $rootDir = rtrim($container->getParameter('kernel.root_dir'), '/');
+        $appSchemaDir = $rootDir . self::APP_SCHEMA_DIR_RELATIVE_PATH;
+        $eZPlatformSchemaDir = $appSchemaDir . self::EZPLATFORM_SCHEMA_DIR_RELATIVE_PATH;
+        $packageRootDir = $rootDir . self::PACKAGE_DIR_RELATIVE_PATH;
+        $fieldsDefinitionFile = $packageRootDir . self::PACKAGE_SCHEMA_DIR_RELATIVE_PATH . DIRECTORY_SEPARATOR . self::FIELS_DEFINITION_FILE_NAME;
+
+        $container->setParameter('ezplatform.graphql.schema.root_dir', $appSchemaDir);
+        $container->setParameter('ezplatform.graphql.schema.ezplatform_dir', $eZPlatformSchemaDir);
+        $container->setParameter('ezplatform.graphql.schema.fields_definition_file', $fieldsDefinitionFile);
+        $container->setParameter('ezplatform.graphql.package.root_dir', $packageRootDir);
+    }
+}

--- a/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
+++ b/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
@@ -1,8 +1,12 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\DependencyInjection;
 
-use EzSystems\EzPlatformGraphQL\DependencyInjection\GraphQL\SchemaProvider;
+use EzSystems\EzPlatformGraphQL\DependencyInjection\GraphQL\YamlSchemaProvider;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -10,21 +14,17 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
 class EzSystemsEzPlatformGraphQLExtension extends Extension implements PrependExtensionInterface
 {
-    /**
-     * @var SchemaProvider
-     */
-    private $schemaProvider;
-
-    public function __construct(SchemaProvider $schemaProvider)
-    {
-        $this->schemaProvider = $schemaProvider;
-    }
+    private const APP_SCHEMA_DIR_RELATIVE_PATH = '/config/graphql';
+    private const EZPLATFORM_SCHEMA_DIR_RELATIVE_PATH = '/ezplatform';
+    private const PACKAGE_DIR_RELATIVE_PATH = '/../vendor/ezsystems/ezplatform-graphql';
+    private const PACKAGE_SCHEMA_DIR_RELATIVE_PATH = '/src/Resources/config/graphql';
+    private const FIELS_DEFINITION_FILE_NAME = 'Field.types.yml';
 
     /**
      * {@inheritdoc}
@@ -34,27 +34,57 @@ class EzSystemsEzPlatformGraphQLExtension extends Extension implements PrependEx
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('schema.yml');
         $loader->load('resolvers.yml');
         $loader->load('services.yml');
     }
 
     /**
-     * Allow an extension to prepend the extension configurations.
+     * {@inheritdoc}
      */
     public function prepend(ContainerBuilder $container)
     {
-        $container->prependExtensionConfig('overblog_graphql', $this->getGraphQLConfig());
+        $this->setContainerParameters($container);
+
+        $configDir = $container->getParameter('ezplatform.graphql.schema.root_dir');
+
+        $container->prependExtensionConfig('overblog_graphql', $this->getGraphQLConfig($configDir));
     }
 
-    private function getGraphQLConfig()
+    /**
+     * Uses YamlConfigProvider to determinate what schema should be used.
+     *
+     * @todo Make it extensible to possibly get rid of Yaml based dynamic schema.
+     *
+     * @param string $configDir
+     *
+     * @return array
+     */
+    private function getGraphQLConfig(string $configDir): array
     {
         return [
             'definitions' => [
                 'config_validation' => '%kernel.debug%',
-                'schema' => $this->schemaProvider->getSchemaConfiguration(),
-            ]
+                'schema' => (new YamlSchemaProvider($configDir))->getSchemaConfiguration(),
+            ],
         ];
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    private function setContainerParameters(ContainerBuilder $container): void
+    {
+        $rootDir = rtrim($container->getParameter('kernel.root_dir'), '/');
+        $appSchemaDir = $rootDir . self::APP_SCHEMA_DIR_RELATIVE_PATH;
+        $eZPlatformSchemaDir = $appSchemaDir . self::EZPLATFORM_SCHEMA_DIR_RELATIVE_PATH;
+        $packageRootDir = $rootDir . self::PACKAGE_DIR_RELATIVE_PATH;
+        $fieldsDefinitionFile = $packageRootDir . self::PACKAGE_SCHEMA_DIR_RELATIVE_PATH . DIRECTORY_SEPARATOR . self::FIELS_DEFINITION_FILE_NAME;
+
+        $container->setParameter('ezplatform.graphql.schema.root_dir', $appSchemaDir);
+        $container->setParameter('ezplatform.graphql.schema.ezplatform_dir', $eZPlatformSchemaDir);
+        $container->setParameter('ezplatform.graphql.schema.fields_definition_file', $fieldsDefinitionFile);
+        $container->setParameter('ezplatform.graphql.package.root_dir', $packageRootDir);
     }
 }

--- a/src/EzSystemsEzPlatformGraphQLBundle.php
+++ b/src/EzSystemsEzPlatformGraphQLBundle.php
@@ -1,32 +1,25 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL;
 
 use EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
-use EzSystems\EzPlatformGraphQL\DependencyInjection\GraphQL\YamlSchemaProvider;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsEzPlatformGraphQLBundle extends Bundle
 {
-    const CONFIG_DIR = __DIR__ . '/../../../../app/config/graphql';
-    const EZPLATFORM_CONFIG_DIR = self::CONFIG_DIR . '/ezplatform';
-    const FIELDS_DEFINITION_FILE = __DIR__ . '/Resources/config/graphql/Field.types.yml';
-
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
 
-        $container->addCompilerPass(new Compiler\FieldValueTypesPass(self::FIELDS_DEFINITION_FILE));
+        $container->addCompilerPass(new Compiler\RegisterSchemaDirectoryParametersPass());
+        $container->addCompilerPass(new Compiler\FieldValueTypesPass());
         $container->addCompilerPass(new Compiler\FieldValueBuildersPass());
         $container->addCompilerPass(new Compiler\SchemaWorkersPass());
         $container->addCompilerPass(new Compiler\SchemaDomainIteratorsPass());
-    }
-
-    protected function createContainerExtension()
-    {
-        if (class_exists($class = $this->getContainerExtensionClass())) {
-            return new $class(new YamlSchemaProvider(self::CONFIG_DIR));
-        }
     }
 }


### PR DESCRIPTION
Previously compiler passes were relying on relative paths to access schema definitions generated in `app/config/graphql/ezplatform` directory. This wasn't really working when symlinks were used during development. I think symlinks are still the best method when working with multiple packages so I couldn't align on my side to overcome this issue.

I have a proposal to move schema directories from constants to container parameters. It's more natural to me to store such information in the container which makes it accessible in services, extensions and compiler passes. 

I will leave it as a draft so we can validate the idea first.