### PR TITLE
Content Domain Iterator should only yield fields from the current content type

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
@@ -101,4 +101,36 @@ class ContentDomainIteratorSpec extends ObjectBehavior
             ])
         );
     }
+
+    function it_only_yields_fields_definitions_from_the_current_content_type(ContentTypeService $contentTypeService)
+    {
+        $contentTypeService->loadContentTypeGroups()->willReturn([
+            $group = new ContentTypeGroup(),
+        ]);
+
+        $contentTypeService->loadContentTypes(Argument::any())->willReturn([
+            $type1 = new ContentType([
+                'identifier' => 'type1',
+                'fieldDefinitions' => [
+                    'type1_field1' => ($type1field1 = new FieldDefinition()),
+                ]
+            ]),
+            $type2 = new ContentType([
+                'identifier' => 'type2',
+                'fieldDefinitions' => [
+                    'type2_field1' => ($type2field1 = new FieldDefinition()),
+                ]
+            ]),
+        ]);
+
+        $this->iterate()->shouldYieldLike(
+            new \ArrayIterator([
+                ['ContentTypeGroup' => $group],
+                ['ContentTypeGroup' => $group, 'ContentType' => $type1],
+                ['ContentTypeGroup' => $group, 'ContentType' => $type1, 'FieldDefinition' => $type1field1],
+                ['ContentTypeGroup' => $group, 'ContentType' => $type2],
+                ['ContentTypeGroup' => $group, 'ContentType' => $type2, 'FieldDefinition' => $type2field1],
+            ])
+        );
+    }
 }

--- a/src/Schema/Domain/Content/ContentDomainIterator.php
+++ b/src/Schema/Domain/Content/ContentDomainIterator.php
@@ -29,16 +29,16 @@ class ContentDomainIterator implements Iterator
     public function iterate(): Generator
     {
         foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
-            $args = ['ContentTypeGroup' => $contentTypeGroup];
-            yield $args;
+            yield ['ContentTypeGroup' => $contentTypeGroup];
 
             foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
-                $args['ContentType'] = $contentType;
-                yield $args;
+                yield ['ContentTypeGroup' => $contentTypeGroup]
+                    + ['ContentType' => $contentType];
 
                 foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
-                    $args['FieldDefinition'] = $fieldDefinition;
-                    yield $args;
+                    yield ['ContentTypeGroup' => $contentTypeGroup]
+                        + ['ContentType' => $contentType]
+                        + ['FieldDefinition' => $fieldDefinition];
                 }
             }
         }


### PR DESCRIPTION
> Fixes [EZP-30265](https://jira.ez.no/browse/EZP-30265)

Fixes a possible leak of items from the surrounding iterations.

Covered by unit test.