### PR TITLE
Fixed image asset field value resolution (EZP-30277)

### DIFF
--- a/src/Schema/Domain/Content/FieldValueBuilder/BaseFieldValueBuilder.php
+++ b/src/Schema/Domain/Content/FieldValueBuilder/BaseFieldValueBuilder.php
@@ -18,7 +18,7 @@ class BaseFieldValueBuilder implements FieldValueBuilder
         'ezfloat' => ['Float', '@=resolver("DomainFieldValue", [value, "%s"]).value'],
         'ezgmaplocation' => 'MapLocationFieldValue',
         'ezimage' => 'ImageFieldValue',
-        'ezimageasset' => ['ImageFieldValue', '@=resolver("DomainImageAssetFieldValue", [value, "%s"]).value'],
+        'ezimageasset' => ['ImageFieldValue', '@=resolver("DomainImageAssetFieldValue", [value, "%s"])'],
         'ezinteger' => ['Int', '@=resolver("DomainFieldValue", [value, "%s"]).value'],
         'ezkeyword' => ['[String]', '@=resolver("DomainFieldValue", [value, "%s"]).values'],
         'ezmedia' => 'MediaFieldValue',


### PR DESCRIPTION
> Fixes [EZP-30277](https://jira.ez.no/browse/EZP-30277)

The generated resolver expected the `value` property out of the returned value, while the value is returned directly.

![image](https://user-images.githubusercontent.com/235928/54598226-5b2fe400-4a38-11e9-84f1-73b9047d34c6.png)
 