### PR TITLE
Fixed ImageVariation lastModified field + other improvements

### DIFF
--- a/src/Resources/config/graphql/Field.types.yml
+++ b/src/Resources/config/graphql/Field.types.yml
@@ -140,8 +140,6 @@ ImageVariation:
                 type: "String"
             fileName:
                 type: "String"
-            dirPath:
-                type: "String"
             lastModified:
                 type: DateTime
 

--- a/src/Resources/config/graphql/Field.types.yml
+++ b/src/Resources/config/graphql/Field.types.yml
@@ -134,14 +134,19 @@ ImageVariation:
         fields:
             uri:
                 type: "String"
+                description: "The image's URI (example: 'https://example.com/var/site/storage/images/_aliases/small/9/8/1/0/189-1-eng-GB/image.png')"
             name:
                 type: "String"
+                description: "The name of the image alias (example: 'original')"
             mimeType:
                 type: "String"
+                description: "The MIME type (for example 'image/png')"
             fileName:
                 type: "String"
+                description: "The name of the file (for example 'my_image.png')"
             lastModified:
                 type: DateTime
+                description: "When the variation was last modified"
 
 AuthorFieldValue:
     type: object

--- a/src/Resources/config/graphql/Field.types.yml
+++ b/src/Resources/config/graphql/Field.types.yml
@@ -143,7 +143,7 @@ ImageVariation:
             dirPath:
                 type: "String"
             lastModified:
-                type: "String"
+                type: DateTime
 
 AuthorFieldValue:
     type: object

--- a/src/Resources/config/graphql/Field.types.yml
+++ b/src/Resources/config/graphql/Field.types.yml
@@ -147,6 +147,12 @@ ImageVariation:
             lastModified:
                 type: DateTime
                 description: "When the variation was last modified"
+            width:
+                type: "Int"
+                description: "The width as number of pixels (example: 320)"
+            height:
+                type: "Int"
+                description: "The height as number of pixels (example: 200)"
 
 AuthorFieldValue:
     type: object


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-30327

Changes the type of `<ImageVariation>.lastModified` to `DateTime`.
In addition:
- described all the fields from `ImageVariation`
- added the `width` and `height` properties
- removed the `dirPath` field, as it returns the same value than `uri` at the moment.

![image](https://user-images.githubusercontent.com/235928/54703294-c95bd000-4b38-11e9-8839-d2972389b962.png)
