### PR TITLE
Added a RepositoryLanguage enum type that lists the configured languages

### DIFF
--- a/doc/domain_schema.md
+++ b/doc/domain_schema.md
@@ -56,7 +56,7 @@ and add that session cookie to the request. With GraphiQL, logging in on another
 mutation CreateBlogPost {
   createBlogPost(
     parentLocationId: 2,
-    languageCode: "eng-GB"
+    language: eng_GB
     input: {
       title: "The blog post's title",
       author: [

--- a/doc/howto/upload_binary_files.md
+++ b/doc/howto/upload_binary_files.md
@@ -14,7 +14,7 @@ GraphQL uses HTTP multipart form-data, like HTTP forms for files uploads, as spe
 curl -v -X POST \
   https://example.com/graphql \
   -H "Cookie: $AUTH_COOKIE" \
-  -F 'operations={"query":"mutation CreateImage($file: FileUpload!) { createImage( parentLocationId: 51, input: { name: \"An image created over GraphQL\", image: { alternativeText: \"The alternative text\", file: $file } }, language: \"eng-GB\" ) { _info { id mainLocationId } _url name image { fileName alternativeText uri } } }","variables":{"file": null}}' \
+  -F 'operations={"query":"mutation CreateImage($file: FileUpload!) { createImage( parentLocationId: 51, language: eng_GB, input: { name: \"An image created over GraphQL\", image: { alternativeText: \"The alternative text\", file: $file } } ) { _info { id mainLocationId } _url name image { fileName alternativeText uri } } }","variables":{"file": null}}' \
   -F 'map={"image":["variables.file"]}' \
   -F "image"=@/path/to/image.png
 ```
@@ -29,7 +29,7 @@ This mutation will create an image content item:
 mutation CreateImage($file: FileUpload!) { 
   createImage( 
     parentLocationId: 51, 
-    language: "eng-GB",
+    language: eng_GB,
     input: { 
       name: "An image created over GraphQL", 
       image: {
@@ -83,7 +83,7 @@ The `UploadFiles` mutation uses the [multi-file upload configuration](https://do
 curl -v -X POST \
   https://localhost:8000/graphql \
   -H 'Cookie: $AUTH_COOKIE' \
-  -F 'operations={"query": "mutation UploadMultipleFiles($files: [FileUpload]!) { uploadFiles( locationId: 51, files: $files, languageCode: \"eng-GB\" ) { files { _url _location { id } ... on ImageContent { name image { uri } } ... on FileContent { name file { uri } } ... on VideoContent { name file { uri } } } warnings } }", "variables": {"files": [null, null, null, null, null]}}' \
+  -F 'operations={"query": "mutation UploadMultipleFiles($files: [FileUpload]!) { uploadFiles( locationId: 51, files: $files, language: eng_GB ) { files { _url _location { id } ... on ImageContent { name image { uri } } ... on FileContent { name file { uri } } ... on VideoContent { name file { uri } } } warnings } }", "variables": {"files": [null, null, null, null, null]}}' \
   -F 'map={"image1":["variables.files.0"], "image2":["variables.files.1"], "file1":["variables.files.2"], "file2":["variables.files.3"], "media":["variables.files.4"]}' \
   -F "image1"=@/tmp/files/image1.png \
   -F "image2"=@/tmp/files/image2.png \
@@ -99,7 +99,7 @@ mutation UploadMultipleFiles($files: [FileUpload]!) {
   uploadFiles(
     locationId: 51, 
     files: $files, 
-    languageCode: "eng-GB"
+    language: eng_GB
   ) {
     files {
       _url
@@ -139,7 +139,7 @@ The HTTP request is similar to the field type example above, except that `$files
 The resulting `operations` file is as follows:
 
 ```
--F 'operations={"query": "mutation BunchOfImages($files: [FileUpload]!) { uploadFiles( locationId: 51, files: $files, languageCode: \"eng-GB\" ) { files { _url _location { id } ... on ImageContent { name image { uri } } ... on FileContent { name file { uri } } ... on VideoContent { name file { uri } } } warnings } }", "variables": {"files": [null, null, null, null, null]}}'
+-F 'operations={"query": "mutation BunchOfImages($files: [FileUpload]!) { uploadFiles( locationId: 51, files: $files, language: eng_GB ) { files { _url _location { id } ... on ImageContent { name image { uri } } ... on FileContent { name file { uri } } ... on VideoContent { name file { uri } } } warnings } }", "variables": {"files": [null, null, null, null, null]}}'
 ```
 
 The map is similar to the one from earlier, with the syntax trick to set each array key individually:

--- a/src/GraphQL/Mutation/UploadFiles.php
+++ b/src/GraphQL/Mutation/UploadFiles.php
@@ -40,7 +40,7 @@ class UploadFiles
             $mapping = $this->mapAgainstConfig($mimeType);
 
             try {
-                $createdContent[] = $this->createContent($mapping, $file, $args['locationId'], $args['languageCode']);
+                $createdContent[] = $this->createContent($mapping, $file, $args['locationId'], $args['language']);
             } catch (\Exception $e) {
                 $warnings[] = $e->getMessage();
             }

--- a/src/GraphQL/Resolver/FieldDefinitionResolver.php
+++ b/src/GraphQL/Resolver/FieldDefinitionResolver.php
@@ -7,14 +7,14 @@ class FieldDefinitionResolver
 {
     public function resolveFieldDefinitionName(FieldDefinition $fieldDefinition, $args)
     {
-        $languageCode = isset($args['languageCode']) ? $args['languageCode'] : null;
+        $languageCode = isset($args['language']) ? $args['language'] : null;
 
         return $fieldDefinition->getName($languageCode);
     }
 
     public function resolveFieldDefinitionDescription(FieldDefinition $fieldDefinition, $args)
     {
-        $languageCode = isset($args['languageCode']) ? $args['languageCode'] : null;
+        $languageCode = isset($args['language']) ? $args['language'] : null;
 
         return $fieldDefinition->getDescription($languageCode);
     }

--- a/src/Resources/config/graphql/ContentType.types.yml
+++ b/src/Resources/config/graphql/ContentType.types.yml
@@ -10,10 +10,10 @@ ContentType:
                 type: "String"
                 description: "The content type's description"
                 args:
-                    languageCode:
-                        type: "String"
-                        defaultValue: ~
-                resolve: "@=value.getDescription(args['languageCode']) ?: ''"
+                    language:
+                      type: "RepositoryLanguage"
+                      defaultValue: ~
+                resolve: "@=value.getDescription(args['language']) ?: ''"
             fieldDefinitions:
                 type: "[FieldDefinition]"
                 description: "The ContentType's Field Definitions."
@@ -28,10 +28,10 @@ ContentType:
                 type: "String"
                 description: "The Content Type's name in the main language"
                 args:
-                    languageCode:
-                        type: "String"
+                    language:
+                        type: "RepositoryLanguage"
                         defaultValue: ~
-                resolve: "@=value.getName(args['languageCode']) ?: ''"
+                resolve: "@=value.getName(args['language']) ?: ''"
             names:
                 type: "[String]"
                 description: "The Content Type's names in all languages"

--- a/src/Resources/config/graphql/FieldDefinition.types.yml
+++ b/src/Resources/config/graphql/FieldDefinition.types.yml
@@ -9,18 +9,19 @@ FieldDefinition:
             name:
                 type: String
                 description: "The field definition name, either in the most prioritized language, or in the language given as an argument"
-                resolve: "@=resolver('FieldDefinitionName', [value, args])"
+                resolve: "@=value.getName(args['language']) ?: ''"
                 args:
-                    languageCode:
-                        type: String
+                    language:
+                        type: RepositoryLanguage
+                        defaultValue: ~
             description:
                 type: String
                 description: "The field definition description, either in the most prioritized language, or in the language given as an argument"
-                resolve: "@=resolver('FieldDefinitionDescription', [value, args])"
+                resolve: "@=value.getDescription(args['language']) ?: ''"
                 args:
-                    languageCode:
-                        type: String
-                        defaultValue: 'default'
+                    language:
+                        type: RepositoryLanguage
+                        defaultValue: ~
             identifier:
                 type: String
                 description: "The system identifier of the field definition."

--- a/src/Resources/config/graphql/PlatformMutation.types.yml
+++ b/src/Resources/config/graphql/PlatformMutation.types.yml
@@ -21,8 +21,8 @@ PlatformMutation:
                         description: "The location ID of a container to upload the files to"
                     files:
                         type: "[FileUpload]!"
-                    languageCode:
-                        type: String!
+                    language:
+                        type: RepositoryLanguage!
                         description: "The language the content items must be created in"
 
 UploadedFilesPayload:

--- a/src/Resources/config/graphql/Version.types.yml
+++ b/src/Resources/config/graphql/Version.types.yml
@@ -18,6 +18,7 @@ Version:
                 args:
                     language:
                         type: RepositoryLanguage
+                resolve: "@=value.getName(args['language']) ?: ''"
             modificationDate:
                 type: "DateTime"
             creationDate:

--- a/src/Resources/config/graphql/Version.types.yml
+++ b/src/Resources/config/graphql/Version.types.yml
@@ -16,8 +16,8 @@ Version:
             name:
                 type: "String"
                 args:
-                    languageCode:
-                        type: "String"
+                    language:
+                        type: RepositoryLanguage
             modificationDate:
                 type: "DateTime"
             creationDate:

--- a/src/Schema/Domain/Content/LanguagesIterator.php
+++ b/src/Schema/Domain/Content/LanguagesIterator.php
@@ -1,0 +1,32 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
+
+use eZ\Publish\API\Repository\LanguageService;
+use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Iterator;
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+use Generator;
+
+class LanguagesIterator implements Iterator
+{
+    /**
+     * @var \eZ\Publish\API\Repository\LanguageService
+     */
+    private $languageService;
+
+    public function __construct(LanguageService $languageService)
+    {
+        $this->languageService = $languageService;
+    }
+    
+    public function init(Builder $schema)
+    {
+    }
+
+    public function iterate(): Generator
+    {
+        foreach ($this->languageService->loadLanguages() as $language) {
+            yield ['Language' => $language];
+        }
+    }
+}

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentMutation.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentMutation.php
@@ -31,7 +31,7 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
                 $this->getNameHelper()->domainContentName($contentType) . '!',
                 [
                     'resolve' => sprintf(
-                        '@=mutation("CreateDomainContent", [args["input"], "%s", args["parentLocationId"], args["languageCode"]])',
+                        '@=mutation("CreateDomainContent", [args["input"], "%s", args["parentLocationId"], args["language"]])',
                         $contentType->identifier
                 )]
             )
@@ -63,7 +63,7 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
             new Builder\Input\Field(
                 $this->getUpdateField($contentType),
                 $this->getNameHelper()->domainContentName($contentType) . '!',
-                ['resolve' => '@=mutation("UpdateDomainContent", [args["input"], args, args["versionNo"], args["languageCode"]])']
+                ['resolve' => '@=mutation("UpdateDomainContent", [args["input"], args, args["versionNo"], args["language"]])']
             )
         );
 

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentMutation.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentMutation.php
@@ -149,9 +149,9 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
     private function buildLanguageFieldInput(): Builder\Input\Arg
     {
         return new Builder\Input\Arg(
-            'languageCode',
-            'String!',
-            ['description' => 'The language code the content should be created/updated in (ex. eng-GB).']
+            'language',
+            'RepositoryLanguage!',
+            ['description' => 'The language the content should be created/updated in.']
         );
     }
 }

--- a/src/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
+++ b/src/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+
+namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\Language;
+
+
+use eZ\Publish\API\Repository\Values\Content\Language;
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+use EzSystems\EzPlatformGraphQL\Schema\Initializer;
+use EzSystems\EzPlatformGraphQL\Schema\Worker;
+
+class AddLanguageToEnum implements Worker, Initializer
+{
+    const ENUM_NAME = 'RepositoryLanguage';
+
+    public function init(Builder $schema)
+    {
+        $schema->addType(
+            new Builder\Input\Type(
+                self::ENUM_NAME,
+                'enum'
+            )
+        );
+    }
+
+    /**
+     * Does the work on $schema.
+     *
+     * @param Builder $schema
+     * @param array $args
+     *
+     * @return void
+     */
+    public function work(Builder $schema, array $args)
+    {
+        /** @var Language $language */
+        $language = $args['Language'];
+
+        $schema->addValueToEnum(
+            self::ENUM_NAME,
+            new Builder\Input\EnumValue(
+                $language->languageCode,
+                [
+                    'description' => $language->name
+                ]
+            )
+        );
+    }
+
+    /**
+     * Tests the arguments and schema, and says if the worker can work on that state.
+     * It includes testing if the worker was already executed.
+     *
+     * @param Builder $schema
+     * @param array $args
+     *
+     * @return bool
+     */
+    public function canWork(Builder $schema, array $args)
+    {
+        return isset($args['Language']) && $args['Language'] instanceof Language;
+}}

--- a/src/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
+++ b/src/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
@@ -45,7 +45,8 @@ class AddLanguageToEnum implements Worker, Initializer
             new Builder\Input\EnumValue(
                 $language->languageCode,
                 [
-                    'description' => $language->name
+                    'description' => $language->name,
+                    'value' => $language->languageCode
                 ]
             )
         );


### PR DESCRIPTION
> Implements [EZP-30328](https://jira.ez.no/browse/EZP-30328)

Adds a `RepositoryLanguage` enum with the languages configured in the repository.
It is used as an argument whenever a language code is accepted/required.

### Content types and fields definitions names and descriptions
```
{
  content {
    _types {
      article {
        _info {
          name(language: fre_FR)
        }
        title {
          name(language: ger_DE)
          description(language: nor_NO)
        }
      }
    }
  }
}
```

### mutations
```
mutation CreateBlogPost {
  createBlogPost(
    parentLocationId: 2,
    language: fre_FR,
    input: { ... }
  )
}
```