### PR TITLE
Fixed content relation value + type

### DIFF
--- a/src/Resources/config/graphql/Content.types.yml
+++ b/src/Resources/config/graphql/Content.types.yml
@@ -100,10 +100,10 @@ ContentRelation:
             sourceFieldDefinitionIdentifier:
                 type: "String"
             sourceContent:
-                type: "Content"
+                type: "DomainContent"
                 resolve: "@=value.sourceContentInfo"
             destinationContent:
-                type: "Content"
+                type: "DomainContent"
                 resolve: "@=value.destinationContentInfo"
             type:
                 type: "String"

--- a/src/Resources/config/graphql/Content.types.yml
+++ b/src/Resources/config/graphql/Content.types.yml
@@ -106,4 +106,14 @@ ContentRelation:
                 type: "DomainContent"
                 resolve: "@=value.destinationContentInfo"
             type:
-                type: "String"
+                type: RelationType
+
+RelationType:
+    type: enum
+    config:
+        values:
+            common: 1
+            embed: 2
+            link: 4
+            field: 8
+            asset: 16

--- a/src/Schema/Domain/Content/FieldValueBuilder/RelationListFieldValueBuilder.php
+++ b/src/Schema/Domain/Content/FieldValueBuilder/RelationListFieldValueBuilder.php
@@ -49,9 +49,4 @@ class RelationListFieldValueBuilder implements FieldValueBuilder
 
         return ['type' => $type, 'resolve' => $resolver];
     }
-
-    private function mapFieldTypeIdentifierToGraphQLType($fieldTypeIdentifier)
-    {
-        return isset($this->typesMap[$fieldTypeIdentifier]) ? $this->typesMap[$fieldTypeIdentifier] : 'GenericFieldValue';
-    }
 }


### PR DESCRIPTION
A small fix, and a small change:

- `Content.relations` and `Content.reverseRelations` will now yield domain content items (e.g. ArticleContent)
- `ContentRelation.type` is now an enumeration with the available types