### PR TITLE
Added plaintext output format for richtext

### DIFF
--- a/src/GraphQL/Resolver/RichTextResolver.php
+++ b/src/GraphQL/Resolver/RichTextResolver.php
@@ -34,4 +34,11 @@ class RichTextResolver
     {
         return $this->richTextEditConverter->convert($document)->saveHTML();
     }
+
+    public function xmlToPlainText(DOMDocument $document)
+    {
+        $html = $this->richTextConverter->convert($document)->saveHTML();
+
+        return strip_tags($html);
+    }
 }

--- a/src/Resources/config/graphql/Field.types.yml
+++ b/src/Resources/config/graphql/Field.types.yml
@@ -389,8 +389,8 @@ RichTextFieldValue:
                 resolve: "@=value"
             plaintext:
                 type: "String"
-                description: "Plain text representation of the value, without tags."
-                resolve: "@=resolver('RichTextXmlToPlainText', [value.xml.plain_text])"
+                description: "Plain text representation of the value, without tags. Warning: the text representation may not be perfect."
+                resolve: "@=resolver('RichTextXmlToPlainText', [value.xml])"
             html5:
                 type: "String"
                 description: "HTML5 representation."

--- a/src/Resources/config/resolvers.yml
+++ b/src/Resources/config/resolvers.yml
@@ -109,6 +109,7 @@ services:
         tags:
             - { name: overblog_graphql.resolver, alias: "RichTextXmlToHtml5", method: "xmlToHtml5" }
             - { name: overblog_graphql.resolver, alias: "RichTextXmlToHtml5Edit", method: "xmlToHtml5Edit" }
+            - { name: overblog_graphql.resolver, alias: "RichTextXmlToPlainText", method: "xmlToplainText" }
 
     EzSystems\EzPlatformGraphQL\GraphQL\Resolver\ImageFieldResolver:
         arguments:


### PR DESCRIPTION
> [EZP-30190](https://jira.ez.no/browse/EZP-30190)

Renders richtext to a plaintext version, using the HTML version passed through `strip_tags()`.