### PR TITLE
Fix EZP-30355: typo in DateFieldInput format

### DIFF
--- a/src/Resources/config/graphql/FieldValueInput.types.yml
+++ b/src/Resources/config/graphql/FieldValueInput.types.yml
@@ -66,7 +66,7 @@ DateInputFormat:
     type: enum
     config:
         values:
-            timetring: {}
+            timestring: {}
             rfc850: {}
             timestamp: {}
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-30355

Fixes `timetring` in DateFieldInput format to `timestring`.