### PR TITLE
EZP-30414: Relation fields aren't resolved

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/GraphQL/Resolver/DomainContentResolverSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/GraphQL/Resolver/DomainContentResolverSpec.php
@@ -2,17 +2,25 @@
 
 namespace spec\EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\Content\Query;
 use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader;
 use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentTypeLoader;
 use EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQueryMapper;
 use EzSystems\EzPlatformGraphQL\GraphQL\Resolver\DomainContentResolver;
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\FieldType;
+use EzSystems\EzPlatformGraphQL\GraphQL\Value\Field;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class DomainContentResolverSpec extends ObjectBehavior
 {
+    const CONTENT_ID = 1;
+
     function let(
         Repository $repository,
         TypeResolver $typeResolver,
@@ -26,5 +34,111 @@ class DomainContentResolverSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType(DomainContentResolver::class);
+    }
+
+    function it_resolves_a_RelationList_field_value_with_multiple_to_an_array(ContentLoader $contentLoader)
+    {
+        $contentArray = $this->createContentList([self::CONTENT_ID]);
+        $field = $this->createRelationListField($contentArray);
+
+        $contentLoader->find($this->createContentIdListQuery($contentArray))->willReturn($contentArray);
+        $this->resolveDomainRelationFieldValue($field, true)->shouldReturn($contentArray);
+    }
+
+    function it_resolves_an_empty_RelationList_field_value_with_multiple_to_an_empty_array(ContentLoader $contentLoader)
+    {
+        $contentArray = [];
+        $field = $this->createRelationListField($contentArray);
+
+        $contentLoader->find(Argument::any())->shouldNotBeCalled();
+        $this->resolveDomainRelationFieldValue($field, true)->shouldReturn([]);
+    }
+
+    function it_resolves_a_Relation_field_value_without_multiple_to_a_content_item(ContentLoader $contentLoader)
+    {
+        $content = $this->createContent(self::CONTENT_ID);
+        $field = $this->createRelationField($content);
+        $contentLoader->find($this->createContentIdListQuery([$content]))->willReturn([$content]);
+
+        $this->resolveDomainRelationFieldValue($field, false)->shouldReturn($content);
+    }
+
+    function it_resolves_an_empty_Relation_field_value_without_multiple_to_null(ContentLoader $contentLoader)
+    {
+        $field = $this->createEmptyRelationField();
+
+        $contentLoader->find(Argument::any())->shouldNotBeCalled();
+        $this->resolveDomainRelationFieldValue($field, false)->shouldReturn(null);
+
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content[] $contentList
+     * @return Field
+     */
+    private function createRelationListField(array $contentList): Field
+    {
+        return new Field(['value' => new FieldType\RelationList\Value($this->extractContentIdList($contentList))]);
+    }
+
+    private function createRelationField(Content $content): Field
+    {
+        return new Field(['value' => new FieldType\Relation\Value($content->id ?? null)]);
+    }
+
+    private function createEmptyRelationField(): Field
+    {
+        return new Field(['value' => new FieldType\Relation\Value()]);
+    }
+
+    private function createContentIdListQuery(array $contentList)
+    {
+        return new Query(['filter' => new Query\Criterion\ContentId($this->extractContentIdList($contentList))]);
+    }
+
+    private function createContentIdQuery(Content $content): Query
+    {
+        return new Query(['filter' => new Query\Criterion\ContentId($content->id)]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content[] $contentList
+     * @return array
+     */
+    private function extractContentIdList(array $contentList): array
+    {
+        return array_map(
+            function (Content $content) {
+                return $content->id;
+            },
+            $contentList
+        );
+    }
+
+    /**
+     * @param int[] $contentIdList
+     * @return Content[]
+     */
+    private function createContentList(array $contentIdList): array
+    {
+        return array_map(
+            function ($contentId) {
+                return $this->createContent($contentId);
+            },
+            $contentIdList
+        );
+    }
+
+    /**
+     * @param $contentId
+     * @return Content
+     */
+    private function createContent($contentId): Content
+    {
+        return new Content([
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo(['id' => $contentId])
+            ])
+        ]);
     }
 }

--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -136,13 +136,7 @@ class DomainContentResolver
 
     public function resolveDomainRelationFieldValue(Field $field, $multiple = false)
     {
-        if ($field->value instanceof FieldType\RelationList\Value) {
-            $destinationContentIds = $field->value->destinationContentIds;
-        } else if ($field->value instanceof FieldType\Relation\Value) {
-            $destinationContentIds = [$field->value->destinationContentId];
-        } else {
-            throw new UserError('\$field does not contain a RelationList or Relation Field value');
-        }
+        $destinationContentIds = $this->getContentIds($field);
 
         if (empty($destinationContentIds) || array_key_exists(0, $destinationContentIds) && is_null($destinationContentIds[0])) {
             return $multiple ? [] : null;
@@ -175,5 +169,21 @@ class DomainContentResolver
     private function getLocationService()
     {
         return $this->repository->getLocationService();
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformGraphQL\GraphQL\Value\Field $field
+     * @return array
+     * @throws UserError if the field isn't a Relation or RelationList value
+     */
+    private function getContentIds(Field $field)
+    {
+        if ($field->value instanceof FieldType\RelationList\Value) {
+            return $field->value->destinationContentIds;
+        } else if ($field->value instanceof FieldType\Relation\Value) {
+            return [$field->value->destinationContentId];
+        } else {
+            throw new UserError('\$field does not contain a RelationList or Relation Field value');
+        }
     }
 }

--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -136,23 +136,28 @@ class DomainContentResolver
 
     public function resolveDomainRelationFieldValue(Field $field, $multiple = false)
     {
-        if (!$field->value instanceof FieldType\RelationList\Value) {
-            throw new UserError("$field->fieldTypeIdentifier is not a RelationList field value");
-        }
-
-        if ($multiple) {
-            if (count($field->value->destinationContentIds) > 0) {
-                return $this->contentLoader->find(new Query(
-                    ['filter' => new Query\Criterion\ContentId($field->value->destinationContentIds)]
-                ));
+        if ($field->value instanceof FieldType\RelationList\Value) {
+            if ($multiple) {
+                if (count($field->value->destinationContentIds) > 0) {
+                    return $this->contentLoader->find(new Query(
+                        ['filter' => new Query\Criterion\ContentId($field->value->destinationContentIds)]
+                    ));
+                } else {
+                    return [];
+                }
             } else {
-                return [];
+                return
+                    isset($field->value->destinationContentIds[0])
+                        ? $this->contentLoader->findSingle(new Query\Criterion\ContentId($field->value->destinationContentIds[0]))
+                        : null;
             }
-        } else {
+        } else if($field->value instanceof FieldType\Relation\Value) {
             return
-                isset($fieldValue->destinationContentIds[0])
-                    ? $this->contentLoader->findSingle(new Query\Criterion\ContentId($field->value->destinationContentIds[0]))
+                isset($field->value->destinationContentId)
+                    ? $this->contentLoader->findSingle(new Query\Criterion\ContentId($field->value->destinationContentId))
                     : null;
+        } else {
+            throw new UserError("$field->fieldTypeIdentifier is not a RelationList field value");
         }
     }
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30414

The `RelationFieldDefinitionMapper` is used for both `ezobjectrelation` and `ezobjectrelationlist`. The resolver is also the same, but was not correctly updated for `ezobjectrelation`, making it return null in every case for it.

The resolver has been changed to always fetch multiple items, and return one or an array depending on the multiple flag.