### PR TITLE
Handle special characters in content type group (EZP-30422)

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/NameHelperSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/NameHelperSpec.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
+
+use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class NameHelperSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(NameHelper::class);
+    }
+
+    function it_removes_special_characters_from_ContentTypeGroup_identifier()
+    {
+        $contentTypeGroup = new ContentTypeGroup(['identifier' => 'Name with-hyphen']);
+        $this->domainGroupName($contentTypeGroup)->shouldBe('DomainGroupNameWithHyphen');
+    }
+}

--- a/src/Schema/Domain/Content/NameHelper.php
+++ b/src/Schema/Domain/Content/NameHelper.php
@@ -147,6 +147,6 @@ class NameHelper
      */
     protected function sanitizeContentTypeGroupIdentifier(ContentTypeGroup $contentTypeGroup): string
     {
-        return str_replace(' ', '_', $contentTypeGroup->identifier);
+        return preg_replace('/[^A-Za-z0-9_]/', '_', $contentTypeGroup->identifier);
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-30422

Changes the normalization of content types groups identifiers to transform all non alphanumeric characters to `_`. It is required on content types groups identifiers as they are actually human readable names.

### TODO
- [ ] Decide if we want to handle other types of special characters (such as accentuated, or even asian). Should we transliterate those ? If yes, using what ?