### PR TITLE
Ignore empty content types groups during generation (EZP-30420)

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomainSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomainSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
+use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup\AddDomainGroupToDomain;
@@ -15,8 +16,9 @@ class AddDomainGroupToDomainSpec extends ContentTypeGroupWorkerBehavior
     const GROUP_TYPE = 'DomainGroupTestGroup';
     const GROUP_FIELD = 'testGroup';
 
-    public function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService)
     {
+        $this->beConstructedWith($contentTypeService);
         $this->setNameHelper($nameHelper);
 
         $nameHelper
@@ -45,6 +47,16 @@ class AddDomainGroupToDomainSpec extends ContentTypeGroupWorkerBehavior
     )
     {
         $schema->hasTypeWithField(self::DOMAIN_TYPE, self::GROUP_FIELD)->willReturn(true);
+        $this->canWork($schema, $this->args())->shouldBe(false);
+    }
+
+    function it_can_not_work_if_the_group_is_empty(
+        SchemaBuilder $schema,
+        ContentTypeService $contentTypeService
+    )
+    {
+        $schema->hasTypeWithField(self::DOMAIN_TYPE, self::GROUP_FIELD)->willReturn(false);
+        $contentTypeService->loadContentTypes(Argument::type(ContentTypeGroup::class))->willReturn([]);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 

--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
+use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup\DefineDomainGroup;
@@ -15,8 +16,9 @@ class DefineDomainGroupSpec extends ContentTypeGroupWorkerBehavior
     const GROUP_TYPE = 'DomainGroupTest';
     const GROUP_TYPES_TYPE = 'DomainGroupTestTypes';
 
-    public function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService)
     {
+        $this->beConstructedWith($contentTypeService);
         $this->setNameHelper($nameHelper);
 
         $nameHelper
@@ -45,6 +47,16 @@ class DefineDomainGroupSpec extends ContentTypeGroupWorkerBehavior
     )
     {
         $schema->hasType(self::GROUP_TYPE)->willReturn(true);
+        $this->canWork($schema, $this->args())->shouldBe(false);
+    }
+
+    function it_can_not_work_if_the_group_is_empty(
+        SchemaBuilder $schema,
+        ContentTypeService $contentTypeService
+    )
+    {
+        $schema->hasType(self::GROUP_TYPE)->willReturn(true);
+        $contentTypeService->loadContentTypes(Argument::type(ContentTypeGroup::class))->willReturn([]);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 

--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypesSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypesSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
+use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup\DefineDomainGroupTypes;
@@ -13,8 +14,9 @@ class DefineDomainGroupTypesSpec extends ContentTypeGroupWorkerBehavior
 {
     const GROUP_TYPES_TYPE = 'DomainGroupTestTypes';
 
-    public function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService)
     {
+        $this->beConstructedWith($contentTypeService);
         $this->setNameHelper($nameHelper);
 
         $nameHelper
@@ -39,6 +41,16 @@ class DefineDomainGroupTypesSpec extends ContentTypeGroupWorkerBehavior
     )
     {
         $schema->hasType(self::GROUP_TYPES_TYPE)->willReturn(true);
+        $this->canWork($schema, $this->args())->shouldBe(false);
+    }
+
+    function it_can_not_work_if_the_group_is_empty(
+        SchemaBuilder $schema,
+        ContentTypeService $contentTypeService
+    )
+    {
+        $schema->hasType(self::GROUP_TYPES_TYPE)->willReturn(false);
+        $contentTypeService->loadContentTypes(Argument::type(ContentTypeGroup::class))->willReturn([]);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 

--- a/src/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
+++ b/src/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
@@ -1,6 +1,7 @@
 <?php
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
+use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
 use EzSystems\EzPlatformGraphQL\Schema\Worker;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
@@ -9,6 +10,16 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 
 final class AddDomainGroupToDomain extends BaseWorker implements Worker
 {
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
     public function work(Builder $schema, array $args)
     {
         $contentTypeGroup = $args['ContentTypeGroup'];
@@ -30,7 +41,8 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
         return
             isset($args['ContentTypeGroup'])
             && $args['ContentTypeGroup'] instanceof ContentTypeGroup
-            && !$schema->hasTypeWithField('Domain', $this->fieldName($args));
+            && !$schema->hasTypeWithField('Domain', $this->fieldName($args))
+            && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
     private function fieldName($args): string

--- a/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
+++ b/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
@@ -1,6 +1,7 @@
 <?php
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
+use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
 use EzSystems\EzPlatformGraphQL\Schema\Worker;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
@@ -9,6 +10,16 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 
 class DefineDomainGroup extends BaseWorker implements Worker
 {
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
     public function work(Builder $schema, array $args)
     {
         $schema->addType(new Input\Type(
@@ -32,7 +43,8 @@ class DefineDomainGroup extends BaseWorker implements Worker
         return
             isset($args['ContentTypeGroup'])
             && $args['ContentTypeGroup'] instanceof ContentTypeGroup
-            && !$schema->hasType($this->typeName($args));
+            && !$schema->hasType($this->typeName($args))
+            && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
     protected function typeName($args): string

--- a/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
+++ b/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
@@ -1,7 +1,7 @@
 <?php
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
-use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
+use eZ\Publish\API\Repository\ContentTypeService;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
 use EzSystems\EzPlatformGraphQL\Schema\Worker;
 use EzSystems\EzPlatformGraphQL\Schema\Builder;
@@ -13,6 +13,16 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
  */
 class DefineDomainGroupTypes extends BaseWorker implements Worker
 {
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
     public function work(Builder $schema, array $args)
     {
         $schema->addType(new Builder\Input\Type($this->typeName($args), 'object'));
@@ -23,7 +33,8 @@ class DefineDomainGroupTypes extends BaseWorker implements Worker
         return
             isset($args['ContentTypeGroup'])
             && $args['ContentTypeGroup'] instanceof ContentTypeGroup
-            && !$schema->hasType($this->typeName($args));
+            && !$schema->hasType($this->typeName($args))
+            && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
     private function typeName($args): string


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-30420

All ContentTypeGroup workers will now ignore empty content types groups.