### PR TITLE
Added a 'viewer' field that exposes a 'user' field with the current user

### DIFF
--- a/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
+++ b/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
@@ -73,7 +73,7 @@ class EzSystemsEzPlatformGraphQLExtension extends Extension implements PrependEx
     {
         $initialConfig = Yaml::parseFile(__DIR__ . '/../Resources/config/overblog_graphql.yaml');
         $initialConfig['definitions']['schema'] = (new YamlSchemaProvider($configDir))->getSchemaConfiguration();
-        $initialConfig['definitions']['types'] = ['NotificationData', 'ContentNotificationData'];
+        $initialConfig['definitions']['schema']['types'] = ['NotificationData', 'ContentNotificationData'];
 
         return $initialConfig;
     }

--- a/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
+++ b/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
@@ -73,6 +73,7 @@ class EzSystemsEzPlatformGraphQLExtension extends Extension implements PrependEx
     {
         $initialConfig = Yaml::parseFile(__DIR__ . '/../Resources/config/overblog_graphql.yaml');
         $initialConfig['definitions']['schema'] = (new YamlSchemaProvider($configDir))->getSchemaConfiguration();
+        $initialConfig['definitions']['types'] = ['NotificationData', 'ContentNotificationData'];
 
         return $initialConfig;
     }

--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -103,6 +103,11 @@ class DomainContentResolver
         return $content;
     }
 
+    public function resolveDomainContentItemById($contentId)
+    {
+        return $this->contentLoader->findSingle(new Query\Criterion\ContentId($contentId));
+    }
+
     /**
      * @param string $contentTypeIdentifier
      *

--- a/src/GraphQL/Resolver/NotificationResolver.php
+++ b/src/GraphQL/Resolver/NotificationResolver.php
@@ -1,0 +1,32 @@
+<?php
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
+
+use eZ\Publish\API\Repository\NotificationService;
+use eZ\Publish\API\Repository\Values\Notification\Notification;
+
+class NotificationResolver
+{
+    /**
+     * @var NotificationService
+     */
+    private $notificationService;
+
+    public function __construct(NotificationService $notificationService)
+    {
+        $this->notificationService = $notificationService;
+    }
+
+    public function currentUserNotifications()
+    {
+        return $this->notificationService->loadNotifications(0, 10);
+    }
+
+    public function notificationType(array $notificationData)
+    {
+        if (isset($notificationData['content_id'])) {
+            return 'ContentNotificationData';
+        } else {
+            return 'NotificationData';
+        }
+    }
+}

--- a/src/GraphQL/Resolver/UserResolver.php
+++ b/src/GraphQL/Resolver/UserResolver.php
@@ -6,10 +6,12 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\UserService;
-use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\API\Repository\Values\User\UserGroup;
+use eZ\Publish\API\Repository\Values;
+use Overblog\GraphQLBundle\Error\UserError;
 
 /**
  * @internal
@@ -20,15 +22,22 @@ class UserResolver
      * @var UserService
      */
     private $userService;
+
     /**
      * @var LocationService
      */
     private $locationService;
 
-    public function __construct(UserService $userService, LocationService $locationService)
+    /**
+     * @var PermissionResolver
+     */
+    private $permissionResolver;
+
+    public function __construct(UserService $userService, LocationService $locationService, PermissionResolver $permissionResolver)
     {
         $this->userService = $userService;
         $this->locationService = $locationService;
+        $this->permissionResolver = $permissionResolver;
     }
 
     public function resolveUser($args)
@@ -61,7 +70,7 @@ class UserResolver
         );
     }
 
-    public function resolveUsersOfGroup(UserGroup $userGroup)
+    public function resolveUsersOfGroup(Values\User\UserGroup $userGroup)
     {
         return $this->userService->loadUsersOfUserGroup(
             $userGroup
@@ -76,7 +85,7 @@ class UserResolver
         return $this->userService->loadUserGroup($userGroupId);
     }
 
-    public function resolveUserGroupSubGroups(UserGroup $userGroup)
+    public function resolveUserGroupSubGroups(Values\User\UserGroup $userGroup)
     {
         return $this->userService->loadSubUserGroups($userGroup);
     }
@@ -90,12 +99,23 @@ class UserResolver
         );
     }
 
-    public function resolveContentFields(Content $content, $args)
+    public function resolveContentFields(Values\Content\Content $content, $args)
     {
         if (isset($args['identifier'])) {
             return [$content->getField($args['identifier'])];
         }
 
         return $content->getFieldsByLanguage();
+    }
+
+    public function resolveCurrentUser(): Values\User\User
+    {
+        try {
+            return $this->userService->loadUser(
+                $this->permissionResolver->getCurrentUserReference()->getUserId()
+            );
+        } catch (NotFoundException $e) {
+            throw new UserError("User not found");
+        }
     }
 }

--- a/src/Resources/config/graphql/Notification.types.yml
+++ b/src/Resources/config/graphql/Notification.types.yml
@@ -1,0 +1,47 @@
+
+Notification:
+    type: object
+    config:
+        fields:
+            id:
+                type: Int
+            owner:
+                type: User
+            isPending:
+                type: Boolean
+            type:
+                type: String
+            created:
+                type: DateTime
+            data:
+                type: NotificationDataInterface
+
+NotificationDataInterface:
+    type: interface
+    config:
+        resolveType: "@=resolver('NotificationType', [value])"
+        fields:
+            title:
+                type: String
+            message:
+                type: String
+
+NotificationData:
+    type: object
+    config:
+        interfaces: [NotificationDataInterface]
+        fields:
+            title:
+                type: String
+            message:
+                type: String
+
+ContentNotificationData:
+    type: object
+    inherits: [NotificationData]
+    config:
+        interfaces: [NotificationDataInterface]
+        fields:
+            content:
+                type: DomainContent
+                resolve: "@=resolver('DomainContentItemById', [value['content_id']])"

--- a/src/Resources/config/graphql/Platform.types.yaml
+++ b/src/Resources/config/graphql/Platform.types.yaml
@@ -16,3 +16,6 @@ Platform:
                 type: Item
                 argsBuilder: "Item"
                 resolve: "@=resolver('Item', [args])"
+            viewer:
+                type: Viewer
+                resolve: { }

--- a/src/Resources/config/graphql/Viewer.types.yml
+++ b/src/Resources/config/graphql/Viewer.types.yml
@@ -5,3 +5,6 @@ Viewer:
             user:
                 type: User
                 resolve: "@=resolver('CurrentUser')"
+            notifications:
+                type: "[Notification]"
+                resolve: "@=resolver('CurrentUserNotifications')"

--- a/src/Resources/config/graphql/Viewer.types.yml
+++ b/src/Resources/config/graphql/Viewer.types.yml
@@ -1,0 +1,7 @@
+Viewer:
+    type: object
+    config:
+        fields:
+            user:
+                type: User
+                resolve: "@=resolver('CurrentUser')"

--- a/src/Resources/config/services/resolvers.yaml
+++ b/src/Resources/config/services/resolvers.yaml
@@ -35,6 +35,7 @@ services:
             - { name: overblog_graphql.resolver, alias: "DomainFieldValue", method: "resolveDomainFieldValue" }
             - { name: overblog_graphql.resolver, alias: "DomainContentType", method: "resolveDomainContentType" }
             - { name: overblog_graphql.resolver, alias: "DomainContentItem", method: "resolveDomainContentItem" }
+            - { name: overblog_graphql.resolver, alias: "DomainContentItemById", method: "resolveDomainContentItemById" }
             - { name: overblog_graphql.resolver, alias: "DomainRelationFieldValue", method: "resolveDomainRelationFieldValue" }
             - { name: overblog_graphql.resolver, alias: "MainUrlAlias", method: "resolveMainUrlAlias" }
         arguments:
@@ -184,3 +185,8 @@ services:
             - { name: overblog_graphql.mutation, alias: "UpdateDomainContent", method: "updateDomainContent" }
 
     EzSystems\EzPlatformGraphQL\GraphQL\Resolver\Map\UploadMap: ~
+
+    EzSystems\EzPlatformGraphQL\GraphQL\Resolver\NotificationResolver:
+        tags:
+            - { name: overblog_graphql.resolver, alias: "CurrentUserNotifications", method: "currentUserNotifications" }
+            - { name: overblog_graphql.resolver, alias: "NotificationType", method: "notificationType" }

--- a/src/Resources/config/services/resolvers.yaml
+++ b/src/Resources/config/services/resolvers.yaml
@@ -73,6 +73,7 @@ services:
             - { name: overblog_graphql.resolver, alias: "UserGroupById", method: "resolveUserGroupById" }
             - { name: overblog_graphql.resolver, alias: "UserGroupSubGroups", method: "resolveUserGroupSubGroups" }
             - { name: overblog_graphql.resolver, alias: "UsersOfGroup", method: "resolveUsersOfGroup" }
+            - { name: overblog_graphql.resolver, alias: "CurrentUser", method: "resolveCurrentUser" }
 
     EzSystems\EzPlatformGraphQL\GraphQL\Resolver\ContentTypeResolver:
         tags:


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-30351

Adds a `viewer` field that gives access to the current user.

```graphql
{
  viewer {
    user {
      name
      login
    }
  }
}
```

```json
{
  "data": {
    "viewer": {
      "user": {
        "name": "Administrator User",
        "login": "admin"
      }
    }
  }
}
```

### Notifications
In addition to `user`, it exposes `notifications`, that yields the viewer's notifications. Notifications data handles the specific case of content notifications, giving access to the content item.

```graphql
{
  viewer {
    notifications {
      id
      created {format(pattern: "d/m/Y H:i:s")}
      data {
        title
        message
        ... on ContentNotificationData {
          content {
            _name
            _url
          }
        }
      }
    } 
  }
}
```

```json
{
  "data": {
    "viewer": {
      "notifications": [
        {
          "id": 2,
          "created": {
            "format": "15/04/2019 16:45:53"
          },
          "data": {
            "title": "Title",
            "message": "Message",
            "content": {
              "_name": "Mexican Street Food",
              "_url": "/Media/Images/tastes/mexican-cuisine/mexican-street-food"
            }
          }
        },
        {
          "id": 1,
          "created": {
            "format": "15/04/2019 16:35:23"
          },
          "data": {
            "title": "Title",
            "message": "Message"
          }
        }
      ]
    }
  }
}
```