### PR TITLE
 [Composer] Prepared ezsystems dependencies for eZ Platform 3.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,8 @@
     "replace": {
         "bdunogier/ezplatform-graphql-bundle": "self.version"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "ezsystems/ezpublish-kernel": "^8.0@dev",
         "ezsystems/ezplatform-admin-ui": "^2.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "overblog/graphiql-bundle": "^0.1",
         "phpspec/phpspec": "^5.1",
         "friendsofphp/php-cs-fixer": "~2.7.1",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "bdunogier/ezplatform-graphql-bundle": "self.version"
     },
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.0|^7.0|^8.0",
-        "ezsystems/ezplatform-admin-ui": "^1.0|^2.0",
+        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-admin-ui": "^2.0@dev",
         "overblog/graphql-bundle": "^0.11",
         "erusev/parsedown": "^1.0"
     },


### PR DESCRIPTION
|      |     |
| --- | --- |
| **Target version** | `master` for eZ Platform `v3.0` |

This PR:
- [x] aligns dependencies to require v3.0-only packages (current `master` of this package is `2.0` so it follows SemVer),
- [x] fixes `mikey179/vfsstream` dependency name (it cannot have uppercase characters),
- [x] sets `minimum-stability` to `dev` but `prefer-stable` to `true` so our unstable dependencies are installed only if stable are not available (needed before releasing eZ Platform 3.0 stable).