### PR TITLE
Bumped php-cs-fixer to v2.15 and added CS check job

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         'simplified_null_return' => false,
         'phpdoc_align' => false,
         'phpdoc_to_comment' => false,
+        'phpdoc_types_order' => false,
         'cast_spaces' => false,
         'blank_line_after_opening_tag' => false,
         'single_blank_line_before_namespace' => false,
@@ -27,6 +28,8 @@ return PhpCsFixer\Config::create()
         'yoda_style' => false,
         'no_break_comment' => false,
         'self_accessor' => false,
+        'native_function_invocation' => false,
+        'native_constant_invocation' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ branches:
     - master
     - dev
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 env:
   matrix:
     - TARGET="phpspec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
   only:
     - master
     - dev
+    - /^\d.\d+$/
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,14 @@ cache:
 env:
   matrix:
     - TARGET="phpspec"
+    - TARGET="codestyle"
 
 before_script:
   - COMPOSER_MEMORY_LIMIT=-1 composer install
 
 script:
   - if [ "$TARGET" == "phpspec" ] ; then ./vendor/bin/phpspec run --format=pretty; fi
+  - if [ "$TARGET" == "codestyle" ] ; then ./vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=estimating; fi
 
 notification:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "overblog/graphiql-bundle": "^0.1",
         "phpspec/phpspec": "^5.1",
-        "friendsofphp/php-cs-fixer": "~2.7.1",
+        "friendsofphp/php-cs-fixer": "~2.15.1",
         "mikey179/vfsstream": "^1.6"
     },
     "autoload": {

--- a/src/Command/GeneratePlatformSchemaCommand.php
+++ b/src/Command/GeneratePlatformSchemaCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -40,9 +41,9 @@ class GeneratePlatformSchemaCommand extends Command
     {
         $this
             ->setName('ezplatform:graphql:generate-schema')
-            ->setDescription("Generates the GraphQL schema for the eZ Platform instance")
+            ->setDescription('Generates the GraphQL schema for the eZ Platform instance')
             ->addOption('dry-run', null, InputOption::VALUE_OPTIONAL, 'Do not write, output the schema only', false)
-            ->addOption('include', null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Type to output or write', []);
+            ->addOption('include', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Type to output or write', []);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/DependencyInjection/Compiler/RichTextInputConvertersPass.php
+++ b/src/DependencyInjection/Compiler/RichTextInputConvertersPass.php
@@ -7,7 +7,6 @@
 namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText as RichTextInputHandler;
-use EzSystems\EzPlatformGraphQL\GraphQL\Resolver\DomainContentMutationResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;

--- a/src/DependencyInjection/Compiler/SchemaDomainIteratorsPass.php
+++ b/src/DependencyInjection/Compiler/SchemaDomainIteratorsPass.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformGraphQL\Schema\Generator;
@@ -15,7 +20,7 @@ class SchemaDomainIteratorsPass implements CompilerPassInterface
         }
 
         $generatorDefinition = $container->getDefinition(Generator::class);
-        
+
         $iterators = [];
         foreach ($container->findTaggedServiceIds('ezplatform_graphql.schema_domain_iterator') as $id => $tags) {
             $iterators[] = new Reference($id);

--- a/src/DependencyInjection/Compiler/SchemaWorkersPass.php
+++ b/src/DependencyInjection/Compiler/SchemaWorkersPass.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformGraphQL\Schema\Generator;
@@ -15,7 +20,7 @@ class SchemaWorkersPass implements CompilerPassInterface
         }
 
         $generatorDefinition = $container->getDefinition(Generator::class);
-        
+
         $workers = [];
         foreach ($container->findTaggedServiceIds('ezplatform_graphql.domain_schema_worker') as $id => $tags) {
             $workers[] = new Reference($id);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,12 +1,16 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files
+ * This is the class that validates and merges configuration from your app/config files.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  */

--- a/src/DependencyInjection/GraphQL/SchemaProvider.php
+++ b/src/DependencyInjection/GraphQL/SchemaProvider.php
@@ -13,6 +13,7 @@ interface SchemaProvider
 {
     /**
      * Returns the overblog graphql schema configuration.
+     *
      * @return array Array with the keys from overlog graphql config: query, mutation, resolver_maps...
      */
     public function getSchemaConfiguration();

--- a/src/DependencyInjection/GraphQL/YamlSchemaProvider.php
+++ b/src/DependencyInjection/GraphQL/YamlSchemaProvider.php
@@ -44,7 +44,7 @@ class YamlSchemaProvider implements SchemaProvider
     {
         if (file_exists($this->getAppQuerySchema())) {
             return 'Query';
-        } else if (file_exists($this->getPlatformQuerySchema())) {
+        } elseif (file_exists($this->getPlatformQuerySchema())) {
             return 'Domain';
         } else {
             return 'Platform';
@@ -55,7 +55,7 @@ class YamlSchemaProvider implements SchemaProvider
     {
         if (file_exists($this->getAppMutationSchemaFile())) {
             return 'Mutation';
-        } else if (file_exists($this->getPlatformMutationSchema())) {
+        } elseif (file_exists($this->getPlatformMutationSchema())) {
             return 'DomainContentMutation';
         } else {
             return null;

--- a/src/Exception/UnsupportedFieldTypeException.php
+++ b/src/Exception/UnsupportedFieldTypeException.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Exception;
 
 use InvalidArgumentException;

--- a/src/GraphQL/InputMapper/SearchQueryMapper.php
+++ b/src/GraphQL/InputMapper/SearchQueryMapper.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\InputMapper;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -8,6 +13,7 @@ class SearchQueryMapper
 {
     /**
      * @param array $inputArray
+     *
      * @return \eZ\Publish\API\Repository\Values\Content\Query
      */
     public function mapInputToQuery(array $inputArray)
@@ -29,15 +35,14 @@ class SearchQueryMapper
             $criteria[] = new Query\Criterion\FullText($inputArray['Text']);
         }
 
-        if (isset($inputArray['Field']))
-        {
+        if (isset($inputArray['Field'])) {
             if (isset($inputArray['Field']['target'])) {
                 $criteria[] = $this->mapInputToFieldCriterion($inputArray['Field']);
             } else {
                 $criteria = array_merge(
                     $criteria,
                     array_map(
-                        function($input) {
+                        function ($input) {
                             return $this->mapInputToFieldCriterion($input);
                         },
                         $inputArray['Field']
@@ -65,6 +70,7 @@ class SearchQueryMapper
                         }
 
                         $lastSortClause->direction = $sortClauseClass;
+
                         return null;
                     }
 
@@ -76,7 +82,7 @@ class SearchQueryMapper
                         return null;
                     }
 
-                    return $lastSortClause = new $sortClauseClass;
+                    return $lastSortClause = new $sortClauseClass();
                 },
                 $inputArray['sortBy']
             );
@@ -98,6 +104,7 @@ class SearchQueryMapper
     /**
      * @param array $queryArg
      * @param $dateMetadata
+     *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\DateMetadata[]
      */
     private function mapDateMetadata(array $queryArg = [], $dateMetadata)
@@ -148,8 +155,9 @@ class SearchQueryMapper
         }
 
         if (!isset($operator)) {
-            throw new InvalidArgumentException("Unspecified operator");
+            throw new InvalidArgumentException('Unspecified operator');
         }
 
-        return new Query\Criterion\Field($input['target'], $operator, $value);    }
+        return new Query\Criterion\Field($input['target'], $operator, $value);
+    }
 }

--- a/src/GraphQL/Mutation/InputHandler/FieldType/Date.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/Date.php
@@ -6,7 +6,6 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType;
 
-use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\SPI\FieldType\Value;
 use EzSystems\EzPlatformGraphQL\Exception\UnsupportedFieldInputFormatException;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;

--- a/src/GraphQL/Mutation/InputHandler/FieldType/Relation.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/Relation.php
@@ -6,7 +6,6 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType;
 
-use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\SPI\FieldType\Value;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;
 

--- a/src/GraphQL/Mutation/InputHandler/FieldType/RelationList.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/RelationList.php
@@ -6,7 +6,6 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType;
 
-use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\SPI\FieldType\Value;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;
 

--- a/src/GraphQL/Mutation/SectionMutation.php
+++ b/src/GraphQL/Mutation/SectionMutation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -56,6 +57,7 @@ class SectionMutation
     /**
      * @param $value
      * @param $section
+     *
      * @return array
      */
     private function mapSectionToPayLoad($value, $section)

--- a/src/GraphQL/Mutation/UploadFiles.php
+++ b/src/GraphQL/Mutation/UploadFiles.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Mutation;
 
 use eZ\Publish\API\Repository\Repository;
@@ -46,7 +51,7 @@ class UploadFiles
             }
         }
 
-        return ['files' => $createdContent, 'warnings' =>$warnings];
+        return ['files' => $createdContent, 'warnings' => $warnings];
     }
 
     private function mapAgainstConfig($mimeType)
@@ -55,7 +60,7 @@ class UploadFiles
             if (in_array($mimeType, $mapping['mimeTypes'])) {
                 return array_filter(
                     $mapping,
-                    function($key) {
+                    function ($key) {
                         return in_array($key, ['contentTypeIdentifier', 'contentFieldIdentifier', 'nameFieldIdentifier']);
                     },
                     ARRAY_FILTER_USE_KEY
@@ -84,8 +89,7 @@ class UploadFiles
         $struct->setField($mapping['nameFieldIdentifier'], $file->getClientOriginalName());
 
         $fieldDefinition = $contentType->getFieldDefinition($mapping['contentFieldIdentifier']);
-        switch ($fieldDefinition->fieldTypeIdentifier)
-        {
+        switch ($fieldDefinition->fieldTypeIdentifier) {
             case 'ezimage':
                 $valueType = FieldType\Image\Value::class;
                 break;
@@ -96,7 +100,7 @@ class UploadFiles
                 $valueType = FieldType\Media\Value::class;
                 break;
             default:
-                throw new UserError("FieldType not supported for upload");
+                throw new UserError('FieldType not supported for upload');
         }
         $struct->setField(
             $mapping['contentFieldIdentifier'],

--- a/src/GraphQL/Relay/DomainConnectionBuilder.php
+++ b/src/GraphQL/Relay/DomainConnectionBuilder.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
 
 use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;

--- a/src/GraphQL/Relay/NodeResolver.php
+++ b/src/GraphQL/Relay/NodeResolver.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
 
 use eZ\Publish\API\Repository\ContentService;

--- a/src/GraphQL/Relay/SearchResolver.php
+++ b/src/GraphQL/Relay/SearchResolver.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
 
 use eZ\Publish\API\Repository\SearchService;
@@ -21,6 +26,7 @@ class SearchResolver
 
     /**
      * @param $args
+     *
      * @return Connection
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException

--- a/src/GraphQL/Resolver/ContentResolver.php
+++ b/src/GraphQL/Resolver/ContentResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -43,12 +44,12 @@ class ContentResolver
     {
         $searchResults = $this->searchService->findContentInfo(
             new Query([
-                'filter' => new Query\Criterion\ContentTypeId($contentTypeId)
+                'filter' => new Query\Criterion\ContentTypeId($contentTypeId),
             ])
         );
 
         return array_map(
-            function(SearchHit $searchHit) {
+            function (SearchHit $searchHit) {
                 return $searchHit->valueObject;
             },
             $searchResults->searchHits
@@ -91,7 +92,7 @@ class ContentResolver
         try {
             $searchResults = $this->searchService->findContentInfo(
                 new Query([
-                    'filter' => new Query\Criterion\ContentId($contentIdList)
+                    'filter' => new Query\Criterion\ContentId($contentIdList),
                 ])
             );
         } catch (\Exception $e) {
@@ -99,7 +100,7 @@ class ContentResolver
         }
 
         return array_map(
-            function(SearchHit $searchHit) {
+            function (SearchHit $searchHit) {
                 return $searchHit->valueObject;
             },
             $searchResults->searchHits

--- a/src/GraphQL/Resolver/ContentTypeResolver.php
+++ b/src/GraphQL/Resolver/ContentTypeResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.

--- a/src/GraphQL/Resolver/DateResolver.php
+++ b/src/GraphQL/Resolver/DateResolver.php
@@ -1,8 +1,12 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use DateTime;
-use Overblog\GraphQLBundle\Definition\Argument;
 
 /**
  * @internal

--- a/src/GraphQL/Resolver/DomainContentMutationResolver.php
+++ b/src/GraphQL/Resolver/DomainContentMutationResolver.php
@@ -294,7 +294,7 @@ class DomainContentMutationResolver
 
     /**
      * Returns the GraphQL schema input field for a field definition.
-     * Example: text_line -> textLine
+     * Example: text_line -> textLine.
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
      *

--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -85,7 +86,7 @@ class DomainContentResolver
         } elseif (isset($args['locationId'])) {
             $criterion = new Query\Criterion\LocationId($args['locationId']);
         } else {
-            throw new UserError("Missing required argument id, remoteId or locationId");
+            throw new UserError('Missing required argument id, remoteId or locationId');
         }
 
         $content = $this->contentLoader->findSingle($criterion);
@@ -101,7 +102,6 @@ class DomainContentResolver
 
     /**
      * @param string $contentTypeIdentifier
-     *
      * @param \Overblog\GraphQLBundle\Definition\Argument $args
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content[]
@@ -138,7 +138,7 @@ class DomainContentResolver
     {
         $destinationContentIds = $this->getContentIds($field);
 
-        if (empty($destinationContentIds) || array_key_exists(0, $destinationContentIds) && is_null($destinationContentIds[0])) {
+        if (empty($destinationContentIds) || array_key_exists(0, $destinationContentIds) && null === $destinationContentIds[0]) {
             return $multiple ? [] : null;
         }
 
@@ -173,14 +173,16 @@ class DomainContentResolver
 
     /**
      * @param \EzSystems\EzPlatformGraphQL\GraphQL\Value\Field $field
+     *
      * @return array
+     *
      * @throws UserError if the field isn't a Relation or RelationList value
      */
     private function getContentIds(Field $field)
     {
         if ($field->value instanceof FieldType\RelationList\Value) {
             return $field->value->destinationContentIds;
-        } else if ($field->value instanceof FieldType\Relation\Value) {
+        } elseif ($field->value instanceof FieldType\Relation\Value) {
             return [$field->value->destinationContentId];
         } else {
             throw new UserError('\$field does not contain a RelationList or Relation Field value');

--- a/src/GraphQL/Resolver/FieldDefinitionResolver.php
+++ b/src/GraphQL/Resolver/FieldDefinitionResolver.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;

--- a/src/GraphQL/Resolver/ImageAssetFieldResolver.php
+++ b/src/GraphQL/Resolver/ImageAssetFieldResolver.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -39,7 +44,7 @@ class ImageAssetFieldResolver
 
         if (empty($assetField->value->alternativeText)) {
             $assetField->value->alternativeText = $field->value->alternativeText;
-        };
+        }
 
         return Field::fromField($assetField);
     }

--- a/src/GraphQL/Resolver/ImageFieldResolver.php
+++ b/src/GraphQL/Resolver/ImageFieldResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -46,8 +47,7 @@ class ImageFieldResolver
         ContentLoader $contentLoader,
         ContentService $contentService,
         array $variations
-    )
-    {
+    ) {
         $this->variationHandler = $variationHandler;
         $this->contentService = $contentService;
         $this->variations = $variations;
@@ -84,7 +84,9 @@ class ImageFieldResolver
 
     /**
      * @param ImageFieldValue $fieldValue
+     *
      * @return [Content, Field]
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
@@ -112,11 +114,12 @@ class ImageFieldResolver
             throw new UserError("Image file {$field->value->id} doesn't exist");
         }
 
-        return array($content, $field);
+        return [$content, $field];
     }
 
     /**
      * @param ImageFieldValue $fieldValue
+     *
      * @return array
      */
     protected function decomposeImageId(ImageFieldValue $fieldValue): array
@@ -125,6 +128,7 @@ class ImageFieldResolver
         if (count($idArray) != 3) {
             throw new UserError("Invalid image ID {$fieldValue->imageId}");
         }
+
         return $idArray;
     }
 }

--- a/src/GraphQL/Resolver/LocationResolver.php
+++ b/src/GraphQL/Resolver/LocationResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -7,7 +8,6 @@ namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
-use Overblog\GraphQLBundle\Resolver\TypeResolver;
 
 /**
  * @internal

--- a/src/GraphQL/Resolver/Map/UploadMap.php
+++ b/src/GraphQL/Resolver/Map/UploadMap.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver\Map;
 
 use Overblog\GraphQLBundle\Resolver\ResolverMap;

--- a/src/GraphQL/Resolver/RichTextResolver.php
+++ b/src/GraphQL/Resolver/RichTextResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.

--- a/src/GraphQL/Resolver/SearchResolver.php
+++ b/src/GraphQL/Resolver/SearchResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -54,12 +55,13 @@ class SearchResolver
         $paginator = new Paginator(function ($offset, $limit) use ($query) {
             $query->offset = $offset;
             $query->limit = $limit ?? 10;
+
             return $this->contentLoader->find($query);
         });
 
         return $paginator->auto(
             $args,
-            function() use ($query) {
+            function () use ($query) {
                 return $this->contentLoader->count($query);
             }
         );

--- a/src/GraphQL/Resolver/SectionResolver.php
+++ b/src/GraphQL/Resolver/SectionResolver.php
@@ -1,13 +1,12 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
-use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\SectionService;
-use Overblog\GraphQLBundle\Resolver\TypeResolver;
 
 /**
  * @internal

--- a/src/GraphQL/Resolver/SelectionFieldResolver.php
+++ b/src/GraphQL/Resolver/SelectionFieldResolver.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use eZ\Publish\API\Repository\Values\Content\Content;

--- a/src/GraphQL/Resolver/UrlAliasResolver.php
+++ b/src/GraphQL/Resolver/UrlAliasResolver.php
@@ -1,14 +1,12 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
-use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\URLAliasService;
-use eZ\Publish\API\Repository\UserService;
-use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
@@ -44,8 +42,7 @@ class UrlAliasResolver
 
     public function resolveUrlAliasType(URLAlias $urlAlias)
     {
-        switch ($urlAlias->type)
-        {
+        switch ($urlAlias->type) {
             case URLAlias::LOCATION:
                 return $this->typeResolver->resolve('LocationUrlAlias');
             case URLAlias::RESOURCE:

--- a/src/GraphQL/Resolver/UserResolver.php
+++ b/src/GraphQL/Resolver/UserResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -94,6 +95,7 @@ class UserResolver
         if (isset($args['identifier'])) {
             return [$content->getField($args['identifier'])];
         }
+
         return $content->getFieldsByLanguage();
     }
 }

--- a/src/GraphQL/Value/ContentFieldValue.php
+++ b/src/GraphQL/Value/ContentFieldValue.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -13,9 +14,9 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  *
  * Required to be able to identify a value's FieldType to map with a GraphQL type.
  *
- * @property-read int $contentTypeId
- * @property-read string $fieldDefIdentifier
- * @property-read object $value
+ * @property int $contentTypeId
+ * @property string $fieldDefIdentifier
+ * @property object $value
  * @
  */
 class ContentFieldValue extends ValueObject
@@ -49,7 +50,7 @@ class ContentFieldValue extends ValueObject
         return parent::__get($property);
     }
 
-    function __toString()
+    public function __toString()
     {
         return (string)$this->value;
     }

--- a/src/GraphQL/Value/Field.php
+++ b/src/GraphQL/Value/Field.php
@@ -1,9 +1,9 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Value;
 
 use eZ\Publish\API\Repository\Values as ApiValues;
@@ -22,7 +22,7 @@ class Field extends ApiValues\Content\Field
         return parent::__get($property);
     }
 
-    function __toString()
+    public function __toString()
     {
         return (string)$this->value;
     }

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema;
 
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
@@ -12,7 +17,6 @@ interface Builder
     /**
      * @param string $type
      * @param Input\Field $field
-     * @return void
      */
     public function addFieldToType($type, Input\Field $field);
 
@@ -20,19 +24,18 @@ interface Builder
      * @param string $type
      * @param string $field
      * @param Input\Arg $argInput
-     * @return void
      */
     public function addArgToField($type, $field, Input\Arg $argInput);
 
     /**
      * @param string $enum
      * @param Input\EnumValue $value
-     * @return void
      */
     public function addValueToEnum($enum, Input\EnumValue $value);
 
     /**
      * @param string $type
+     *
      * @return bool
      */
     public function hasType($type): bool;
@@ -40,6 +43,7 @@ interface Builder
     /**
      * @param string $type
      * @param string $field
+     *
      * @return bool
      */
     public function hasTypeWithField($type, $field): bool;
@@ -48,12 +52,14 @@ interface Builder
      * @param string $type
      * @param string $field
      * @param $arg
+     *
      * @return bool
      */
     public function hasTypeFieldWithArg($type, $field, $arg): bool;
 
     /**
      * @param string $enum
+     *
      * @return bool
      */
     public function hasEnum($enum): bool;

--- a/src/Schema/Builder/Input/Arg.php
+++ b/src/Schema/Builder/Input/Arg.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 
 class Arg extends Input

--- a/src/Schema/Builder/Input/EnumValue.php
+++ b/src/Schema/Builder/Input/EnumValue.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 
 class EnumValue extends Input

--- a/src/Schema/Builder/Input/Field.php
+++ b/src/Schema/Builder/Input/Field.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 
 class Field extends Input

--- a/src/Schema/Builder/Input/Input.php
+++ b/src/Schema/Builder/Input/Input.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 
 abstract class Input

--- a/src/Schema/Builder/Input/Type.php
+++ b/src/Schema/Builder/Input/Type.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 
 class Type extends Input

--- a/src/Schema/Builder/SchemaBuilder.php
+++ b/src/Schema/Builder/SchemaBuilder.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Builder;
 
 use EzSystems\EzPlatformGraphQL\Schema\Builder as SchemaBuilderInterface;
@@ -26,7 +31,7 @@ class SchemaBuilder implements SchemaBuilderInterface
         }
         if (!empty($typeInput->interfaces)) {
             $type['config']['interfaces'] = is_array($typeInput->interfaces)
-                ? $typeInput->interfaces:
+                ? $typeInput->interfaces :
                 [$typeInput->interfaces];
         }
 
@@ -109,6 +114,7 @@ class SchemaBuilder implements SchemaBuilderInterface
 
     /**
      * @param string $type
+     *
      * @return bool
      */
     public function hasType($type): bool
@@ -119,6 +125,7 @@ class SchemaBuilder implements SchemaBuilderInterface
     /**
      * @param string $type
      * @param string $field
+     *
      * @return bool
      */
     public function hasTypeWithField($type, $field): bool
@@ -132,6 +139,7 @@ class SchemaBuilder implements SchemaBuilderInterface
      * @param string $type
      * @param string $field
      * @param $arg
+     *
      * @return bool
      */
     public function hasTypeFieldWithArg($type, $field, $arg): bool
@@ -143,6 +151,7 @@ class SchemaBuilder implements SchemaBuilderInterface
 
     /**
      * @param string $enum
+     *
      * @return bool
      */
     public function hasEnum($enum): bool

--- a/src/Schema/Domain/Content/ContentDomainIterator.php
+++ b/src/Schema/Domain/Content/ContentDomainIterator.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
 
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
@@ -18,7 +23,7 @@ class ContentDomainIterator implements Iterator
     {
         $this->contentTypeService = $contentTypeService;
     }
-    
+
     public function init(Builder $schema)
     {
         $schema->addType(

--- a/src/Schema/Domain/Content/LanguagesIterator.php
+++ b/src/Schema/Domain/Content/LanguagesIterator.php
@@ -1,8 +1,12 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
 
 use eZ\Publish\API\Repository\LanguageService;
-use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Iterator;
 use EzSystems\EzPlatformGraphQL\Schema\Builder;
 use Generator;
@@ -18,7 +22,7 @@ class LanguagesIterator implements Iterator
     {
         $this->languageService = $languageService;
     }
-    
+
     public function init(Builder $schema)
     {
     }

--- a/src/Schema/Domain/Content/NameHelper.php
+++ b/src/Schema/Domain/Content/NameHelper.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -96,41 +101,40 @@ class NameHelper
     private function pluralize($name)
     {
         if (substr($name, -1) === 'f') {
-            return substr($name, 0, -1) . "ves";
+            return substr($name, 0, -1) . 'ves';
         }
 
         if (substr($name, -1) === 'fe') {
-            return substr($name, 0, -2) . "ves";
+            return substr($name, 0, -2) . 'ves';
         }
 
         if (substr($name, -1) === 'y') {
-
             if (in_array(substr($name, -2, 1), ['a', 'e', 'i', 'o', 'u'])) {
                 return $name . 's';
             } else {
-                return substr($name, 0, -1) . "ies";
+                return substr($name, 0, -1) . 'ies';
             }
         }
 
         if (substr($name, -2) === 'is') {
-            return substr($name, 0, -2) . "es";
+            return substr($name, 0, -2) . 'es';
         }
 
         if (substr($name, -2) === 'us') {
-            return substr($name, 0, -2) . "i";
+            return substr($name, 0, -2) . 'i';
         }
 
         if (in_array(substr($name, -2), ['on', 'um'])) {
-            return substr($name, 0, -2) . "a";
+            return substr($name, 0, -2) . 'a';
         }
 
         if (substr($name, -2) === 'is') {
-            return substr($name, 0, -2) . "es";
+            return substr($name, 0, -2) . 'es';
         }
 
         if (
             preg_match('/(s|sh|ch|x|z)$/', $name) ||
-            substr($name, -1) ===  'o'
+            substr($name, -1) === 'o'
         ) {
             return $name . 'es';
         }
@@ -140,9 +144,10 @@ class NameHelper
 
     /**
      * Removes potential spaces in content types groups names.
-     * (content types groups identifiers are actually their name)
+     * (content types groups identifiers are actually their name).
      *
      * @param ContentTypeGroup $contentTypeGroup
+     *
      * @return string
      */
     protected function sanitizeContentTypeGroupIdentifier(ContentTypeGroup $contentTypeGroup): string

--- a/src/Schema/Domain/Content/Worker/BaseWorker.php
+++ b/src/Schema/Domain/Content/Worker/BaseWorker.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;

--- a/src/Schema/Domain/Content/Worker/ContentType/AddContentOfTypeConnectionToDomainGroup.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/AddContentOfTypeConnectionToDomainGroup.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
@@ -30,12 +35,12 @@ class AddContentOfTypeConnectionToDomainGroup extends BaseWorker implements Work
 
         $schema->addArgToField($this->groupName($args), $this->connectionField($args), new Input\Arg(
             'query', 'ContentSearchQuery',
-            ['description' => "A Content query used to filter results"]
+            ['description' => 'A Content query used to filter results']
         ));
 
         $schema->addArgToField($this->groupName($args), $this->connectionField($args), new Input\Arg(
             'sortBy', '[SortByOptions]',
-            ['description' => "A sort clause, or array of clauses. Add _desc after a clause to reverse it"]
+            ['description' => 'A sort clause, or array of clauses. Add _desc after a clause to reverse it']
         ));
     }
 

--- a/src/Schema/Domain/Content/Worker/ContentType/AddContentTypeToContentTypeIdentifierList.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/AddContentTypeToContentTypeIdentifierList.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
@@ -9,7 +14,7 @@ use EzSystems\EzPlatformGraphQL\Schema\Builder;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
- * Adds a content type to the content type identifiers list (ContentTypeIdentifier)
+ * Adds a content type to the content type identifiers list (ContentTypeIdentifier).
  */
 class AddContentTypeToContentTypeIdentifierList extends BaseWorker implements Worker, Initializer
 {

--- a/src/Schema/Domain/Content/Worker/ContentType/AddContentTypeToDomainGroupTypes.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/AddContentTypeToDomainGroupTypes.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;

--- a/src/Schema/Domain/Content/Worker/ContentType/AddDomainContentToDomainGroup.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/AddDomainContentToDomainGroup.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
@@ -19,7 +24,7 @@ class AddDomainContentToDomainGroup extends BaseWorker implements Worker
             $this->typeField($args), $this->typeName($args),
             [
                 'description' => isset($descriptions['eng-GB']) ? $descriptions['eng-GB'] : 'No description available',
-                'resolve' => sprintf('@=resolver("DomainContentItem", [args, "%s"])', $contentType->identifier)
+                'resolve' => sprintf('@=resolver("DomainContentItem", [args, "%s"])', $contentType->identifier),
             ]
         ));
 

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContent.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContent.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
@@ -15,7 +20,7 @@ class DefineDomainContent extends BaseWorker implements Worker
             $this->typeName($args), 'object',
             [
                 'inherits' => 'AbstractDomainContent',
-                'interfaces' => ['DomainContent', 'Node']
+                'interfaces' => ['DomainContent', 'Node'],
             ]
         ));
     }

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentConnection.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentConnection.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;
@@ -6,7 +11,6 @@ use EzSystems\EzPlatformGraphQL\Schema\Worker;
 use EzSystems\EzPlatformGraphQL\Schema\Builder;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
-use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 
 class DefineDomainContentConnection extends BaseWorker implements Worker
 {

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentMutation.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentMutation.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -33,7 +38,7 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
                     'resolve' => sprintf(
                         '@=mutation("CreateDomainContent", [args["input"], "%s", args["parentLocationId"], args["language"]])',
                         $contentType->identifier
-                )]
+                ), ]
             )
         );
 
@@ -110,6 +115,7 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
 
     /**
      * @param $contentType
+     *
      * @return string
      */
     protected function getCreateInputName($contentType): string
@@ -119,6 +125,7 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
 
     /**
      * @param $contentType
+     *
      * @return string
      */
     protected function getUpdateInputName($contentType): string
@@ -128,6 +135,7 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
 
     /**
      * @param $contentType
+     *
      * @return string
      */
     protected function getCreateField($contentType): string
@@ -137,6 +145,7 @@ class DefineDomainContentMutation extends BaseWorker implements Worker, Initiali
 
     /**
      * @param $contentType
+     *
      * @return string
      */
     protected function getUpdateField($contentType): string

--- a/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentType.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/DefineDomainContentType.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\BaseWorker;

--- a/src/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
+++ b/src/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
 use eZ\Publish\API\Repository\ContentTypeService;
@@ -24,14 +29,14 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
     {
         $contentTypeGroup = $args['ContentTypeGroup'];
         $schema->addFieldToType('Domain', new Input\Field(
-            $this->fieldName($args), 
+            $this->fieldName($args),
             $this->typeGroupName($args),
             [
                 'description' => $contentTypeGroup->getDescription('eng-GB'),
                 'resolve' => sprintf(
                     '@=resolver("ContentTypeGroupByIdentifier", ["%s"])',
                     $contentTypeGroup->identifier
-                )
+                ),
             ]
         ));
     }

--- a/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
+++ b/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
 use eZ\Publish\API\Repository\ContentTypeService;

--- a/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
+++ b/src/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
 use eZ\Publish\API\Repository\ContentTypeService;
@@ -9,7 +14,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 
 /**
  * Defines the type that indexes the types from a group by identifier.
- * Example: 'DomainGroupContentTypes'
+ * Example: 'DomainGroupContentTypes'.
  */
 class DefineDomainGroupTypes extends BaseWorker implements Worker
 {

--- a/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
+++ b/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToDomainContentMutation.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\FieldDefinition;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -14,7 +19,8 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Wo
 
     /**
      * Mapping of fieldtypes identifiers to their GraphQL input type.
-     * @var String[]
+     *
+     * @var string[]
      */
     private $typesInputMap;
 
@@ -61,6 +67,7 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Wo
 
     /**
      * @param ContentType $contentType
+     *
      * @return string
      */
     protected function getCreateInputName(ContentType $contentType): string
@@ -70,6 +77,7 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Wo
 
     /**
      * @param ContentType $contentType
+     *
      * @return string
      */
     private function getUpdateInputName($contentType): string
@@ -79,6 +87,7 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Wo
 
     /**
      * @param FieldDefinition $fieldDefinition
+     *
      * @return string
      */
     protected function getFieldDefinitionField(FieldDefinition $fieldDefinition): string
@@ -88,7 +97,7 @@ class AddFieldDefinitionToDomainContentMutation extends BaseWorker implements Wo
 
     private function getFieldDefinitionToGraphQLType(FieldDefinition $fieldDefinition, $operation): string
     {
-        $requiredFlag = $operation == self::OPERATION_CREATE && $fieldDefinition->isRequired ? '!': '';
+        $requiredFlag = $operation == self::OPERATION_CREATE && $fieldDefinition->isRequired ? '!' : '';
 
         return isset($this->typesInputMap[$fieldDefinition->fieldTypeIdentifier])
             ? ($this->typesInputMap[$fieldDefinition->fieldTypeIdentifier] . $requiredFlag)

--- a/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToDomainContentType.php
+++ b/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToDomainContentType.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\FieldDefinition;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
@@ -49,6 +54,7 @@ class AddFieldDefinitionToDomainContentType extends BaseWorker implements Worker
 
     /**
      * @param array $args
+     *
      * @return string
      */
     protected function typeName(array $args): string

--- a/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
+++ b/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\FieldDefinition;
 
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
@@ -8,7 +13,6 @@ use EzSystems\EzPlatformGraphQL\Schema\Builder;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
-
 
 class AddFieldValueToDomainContent extends BaseWorker implements Worker
 {
@@ -35,7 +39,7 @@ class AddFieldValueToDomainContent extends BaseWorker implements Worker
     {
         return [
             'type' => $this->fieldDefinitionMapper->mapToFieldValueType($fieldDefinition),
-            'resolve' => $this->fieldDefinitionMapper->mapToFieldValueResolver($fieldDefinition)
+            'resolve' => $this->fieldDefinitionMapper->mapToFieldValueResolver($fieldDefinition),
         ];
     }
 

--- a/src/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
+++ b/src/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
@@ -1,12 +1,10 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
-
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\Language;
-
 
 use eZ\Publish\API\Repository\Values\Content\Language;
 use EzSystems\EzPlatformGraphQL\Schema\Builder;
@@ -32,8 +30,6 @@ class AddLanguageToEnum implements Worker, Initializer
      *
      * @param Builder $schema
      * @param array $args
-     *
-     * @return void
      */
     public function work(Builder $schema, array $args)
     {
@@ -46,7 +42,7 @@ class AddLanguageToEnum implements Worker, Initializer
                 $language->languageCode,
                 [
                     'description' => $language->name,
-                    'value' => $language->languageCode
+                    'value' => $language->languageCode,
                 ]
             )
         );
@@ -64,4 +60,5 @@ class AddLanguageToEnum implements Worker, Initializer
     public function canWork(Builder $schema, array $args)
     {
         return isset($args['Language']) && $args['Language'] instanceof Language;
-}}
+    }
+}

--- a/src/Schema/Domain/ImageVariationDomain.php
+++ b/src/Schema/Domain/ImageVariationDomain.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;

--- a/src/Schema/Domain/Iterator.php
+++ b/src/Schema/Domain/Iterator.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain;
 
 use EzSystems\EzPlatformGraphQL\Schema\Builder;
@@ -11,7 +16,9 @@ interface Iterator
 {
     /**
      * Performs one-time initializations on the schema.
+     *
      * @param Builder $schema
+     *
      * @return
      */
     public function init(Builder $schema);

--- a/src/Schema/Generator.php
+++ b/src/Schema/Generator.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema;
 
 class Generator
@@ -9,7 +14,8 @@ class Generator
     private $schema;
 
     /**
-     * Grouping of schema types for writing to disk (group => [types])
+     * Grouping of schema types for writing to disk (group => [types]).
+     *
      * @var array
      */
     private $groups;
@@ -53,7 +59,7 @@ class Generator
                 }
             }
         }
-        
+
         return $this->schema->getSchema();
     }
 }

--- a/src/Schema/ImagesVariationsBuilder.php
+++ b/src/Schema/ImagesVariationsBuilder.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
@@ -23,11 +28,11 @@ class ImagesVariationsBuilder implements SchemaBuilder
         $schema['ImageVariationIdentifier'] = [
             'type' => 'enum',
             'config' => [
-                'values' => []
-            ]
+                'values' => [],
+            ],
         ];
 
-        $values =& $schema['ImageVariationIdentifier']['config']['values'];
+        $values = &$schema['ImageVariationIdentifier']['config']['values'];
 
         foreach (array_keys($this->configResolver->getParameter('image_variations')) as $variationIdentifier) {
             $values[$variationIdentifier] = [];

--- a/src/Schema/Initializer.php
+++ b/src/Schema/Initializer.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema;
 
 interface Initializer

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema;
 
 interface SchemaBuilder

--- a/src/Schema/SchemaGenerator.php
+++ b/src/Schema/SchemaGenerator.php
@@ -1,15 +1,10 @@
 <?php
-namespace EzSystems\EzPlatformGraphQL\Schema;
 
-use EzSystems\EzPlatformGraphQL\DomainContent\SchemaWorker\ContentTypeGroup\ContentTypeGroupSchemaWorker;
-use EzSystems\EzPlatformGraphQL\DomainContent\SchemaWorker\ContentType\ContentTypeSchemaWorker;
-use EzSystems\EzPlatformGraphQL\DomainContent\SchemaWorker\FieldDefinition\FieldDefinitionSchemaWorker;
-use EzSystems\EzPlatformGraphQL\DomainContent\SchemaWorker\SchemaWorker;
-use EzSystems\EzPlatformGraphQL\Schema\SchemaBuilder;
-use eZ\Publish\API\Repository\Repository;
-use GraphQL\Type\Schema;
-use InvalidArgumentException;
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\Schema;
 
 class SchemaGenerator
 {
@@ -32,8 +27,7 @@ class SchemaGenerator
         foreach ($this->schemaBuilders as $builder) {
             $builder->build($schema);
         }
-        
+
         return $schema;
     }
-
 }

--- a/src/Schema/Worker.php
+++ b/src/Schema/Worker.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace EzSystems\EzPlatformGraphQL\Schema;
 
 interface Worker
@@ -8,7 +13,6 @@ interface Worker
      *
      * @param Builder $schema
      * @param array $args
-     * @return void
      */
     public function work(Builder $schema, array $args);
 
@@ -18,6 +22,7 @@ interface Worker
      *
      * @param Builder $schema
      * @param array $args
+     *
      * @return bool
      */
     public function canWork(Builder $schema, array $args);


### PR DESCRIPTION
|      |     |
| --- | --- |
| **Type** | Bug |
| **Target version** | `v1.0.2` for eZ Platform `v2.5.2 LTS` |

This PR:
- [x] bumps php-cs-fixer to v2.15.1 (locking `>=2.15.1 <2.16.0`),
- [x] adds composer cache directory to Travis cached directories,
- [x] adds a Travis job which checks code style ([failing build](https://travis-ci.org/ezsystems/ezplatform-rest/jobs/549685935), [passing build](https://travis-ci.org/ezsystems/ezplatform-graphql/builds/549706248?utm_source=github_status&utm_medium=notification)),
- [x] adds running Travis on stable branches (e.g. `1.0`),
- [x] disables unwanted CS rules,
- [x] fixes outstanding CS issues.