### PR TITLE
EZP-30691: Dropped unused dependency from GeneratePlatformSchemaCommand

### DIFF
--- a/src/Command/GeneratePlatformSchemaCommand.php
+++ b/src/Command/GeneratePlatformSchemaCommand.php
@@ -7,7 +7,6 @@
 namespace EzSystems\EzPlatformGraphQL\Command;
 
 use EzSystems\EzPlatformGraphQL\Schema\Generator;
-use eZ\Publish\API\Repository\Repository;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,21 +18,15 @@ use Symfony\Component\Yaml\Yaml;
 class GeneratePlatformSchemaCommand extends Command
 {
     /**
-     * @var \eZ\Publish\API\Repository\Repository
-     */
-    private $repository;
-
-    /**
      * @var \EzSystems\EzPlatformGraphQL\Schema\Generator
      */
     private $generator;
 
     const TYPES_DIRECTORY = 'app/config/graphql/ezplatform';
 
-    public function __construct(Repository $repository, Generator $generator)
+    public function __construct(Generator $generator)
     {
         parent::__construct();
-        $this->repository = $repository;
         $this->generator = $generator;
     }
 


### PR DESCRIPTION
|      |     |
| --- | --- |
| **Type** | Bug |
| **Target version** | `v1.0.2` for eZ Platform `v2.5.2 LTS` |
| **Requires** | #44 

Commit relevant for review: ef19288

The `ezplatform:graphql:generate-schema `(`\EzSystems\EzPlatformGraphQL\Command\GeneratePlatformSchemaCommand`) command relies on Repository but does not use it.

Right now it only generates warnings (introduced via ezsystems/ezpublish-kernel#2636) from time to time, when building container, so we should drop it.

**TODO**
- [x] **Before merge**: rebase after merging #44 