### PR TITLE
Removed a duplicate field definition in Search.types.yaml

### DIFF
--- a/src/Resources/config/graphql/Search.types.yml
+++ b/src/Resources/config/graphql/Search.types.yml
@@ -48,9 +48,6 @@ FieldCriterionInput:
              gt:
                  description: "Greater than the value"
                  type: "String"
-             contains:
-                 description: "Contains than the value"
-                 type: "String"
              gte:
                  description: "Greater than or equal to the value"
                  type: 'String'


### PR DESCRIPTION
Was silently failing with Sf3, but doesn't stay silent with Sf4.