### PR TITLE
Location by id with children support

### DIFF
--- a/src/GraphQL/DataLoader/Exception/ArgumentsException.php
+++ b/src/GraphQL/DataLoader/Exception/ArgumentsException.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\Exception;
+
+use Exception;
+
+class ArgumentsException extends Exception
+{
+}

--- a/src/GraphQL/DataLoader/LocationLoader.php
+++ b/src/GraphQL/DataLoader/LocationLoader.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\DataLoader;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * @internal
+ */
+interface LocationLoader
+{
+    /**
+     * Loads a list of locations given a Query Criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location[]
+     */
+    public function find(LocationQuery $query): array;
+
+    /**
+     * Loads a single content item given a Query Criterion.
+     *
+     * @param string $id a location id
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    public function findById($id): Location;
+
+    /**
+     * Loads a single content item given a Query Criterion.
+     *
+     * @param string $remoteId A location remote id
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    public function findByRemoteId($remoteId): Location;
+
+    /**
+     * Counts the results of a query.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
+     *
+     * @return int
+     */
+    public function count(LocationQuery $query);
+}

--- a/src/GraphQL/InputMapper/SearchQuerySortByMapper.php
+++ b/src/GraphQL/InputMapper/SearchQuerySortByMapper.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\InputMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+class SearchQuerySortByMapper
+{
+    /**
+     * @param string[] $sortInput
+     *
+     * @return \eZ\Publish\API\Repository\Values\URL\Query\SortClause[]
+     */
+    public function mapInputToSortClauses(array $sortInput)
+    {
+        $sortClauses = array_map(
+            function (string $sortClauseClass) {
+                /** @var Query\SortClause $lastSortClause */
+                static $lastSortClause;
+
+                if ($sortClauseClass === Query::SORT_DESC) {
+                    if (!$lastSortClause instanceof Query\SortClause) {
+                        return null;
+                    }
+
+                    $lastSortClause->direction = $sortClauseClass;
+
+                    return null;
+                }
+
+                if (!class_exists($sortClauseClass)) {
+                    return null;
+                }
+
+                if (!in_array(Query\SortClause::class, class_parents($sortClauseClass))) {
+                    return null;
+                }
+
+                return $lastSortClause = new $sortClauseClass();
+            },
+            $sortInput
+        );
+
+        return array_filter($sortClauses);
+    }
+}

--- a/src/GraphQL/Relay/Page.php
+++ b/src/GraphQL/Relay/Page.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
+
+/**
+ * A Page in a PageAwareConnection.
+ */
+class Page
+{
+    /** @var int */
+    public $number;
+
+    /** @var string */
+    public $cursor;
+
+    public function __construct(int $number, string $cursor)
+    {
+        $this->number = $number;
+        $this->cursor = $cursor;
+    }
+}

--- a/src/GraphQL/Relay/PageAwareConnection.php
+++ b/src/GraphQL/Relay/PageAwareConnection.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Relay;
+
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
+use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+use Overblog\GraphQLBundle\Relay\Connection\Output\Edge;
+use Overblog\GraphQLBundle\Relay\Connection\Output\PageInfo;
+
+final class PageAwareConnection
+{
+    /** @var Edge[] */
+    public $edges = [];
+
+    /** @var PageInfo */
+    public $pageInfo;
+
+    /** @var int */
+    public $totalCount;
+
+    /** @var Page[] */
+    public $pages;
+
+    public function __construct(array $edges, PageInfo $pageInfo)
+    {
+        $this->edges = $edges;
+        $this->pageInfo = $pageInfo;
+    }
+
+    public static function fromConnection(Connection $connection, Argument $args): PageAwareConnection
+    {
+        $return = new self($connection->edges, $connection->pageInfo);
+        $return->totalCount = $connection->totalCount;
+
+        $return->pages = [];
+
+        $perPage = $args['first'] ?? $args['last'] ?? 10;
+        $totalPages = ceil($return->totalCount / $perPage);
+        for ($pageNumber = 2; $pageNumber <= $totalPages; ++$pageNumber) {
+            $offset = ($pageNumber - 1) * $perPage - 1;
+            $return->pages[] = new Page($pageNumber, ConnectionBuilder::offsetToCursor($offset));
+        }
+
+        return $return;
+    }
+}

--- a/src/GraphQL/Resolver/ContentResolver.php
+++ b/src/GraphQL/Resolver/ContentResolver.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 
 /**
  * @internal
@@ -112,5 +113,10 @@ class ContentResolver
         return $this->contentService->loadVersions(
             $this->contentService->loadContentInfo($contentId)
         );
+    }
+
+    public function resolveCurrentVersion(ContentInfo $contentInfo): VersionInfo
+    {
+        return $this->contentService->loadVersionInfo($contentInfo);
     }
 }

--- a/src/GraphQL/Resolver/ContentThumbnailResolver.php
+++ b/src/GraphQL/Resolver/ContentThumbnailResolver.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
+
+use Exception;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\FieldType;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader;
+
+final class ContentThumbnailResolver
+{
+    const THUMBNAIL_VARIATION_IDENTIFIER = 'medium';
+
+    /**
+     * @var \EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentLoader
+     */
+    private $contentLoader;
+    /**
+     * @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper
+     */
+    private $assetMapper;
+    /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     */
+    private $variationHandler;
+    /**
+     * @var \eZ\Publish\Core\FieldType\Image\Type
+     */
+    private $imageFieldType;
+
+    public function __construct(
+        FieldType\Image\Type $imageFieldType,
+        ContentLoader $contentLoader,
+        FieldType\ImageAsset\AssetMapper $assetMapper,
+        VariationHandler $variationHandler)
+    {
+        $this->contentLoader = $contentLoader;
+        $this->assetMapper = $assetMapper;
+        $this->variationHandler = $variationHandler;
+        $this->imageFieldType = $imageFieldType;
+    }
+
+    /**
+     * @param Content $content
+     *
+     * @return array|null array with the thumbnail info, or null if no thumbnail could be obtained for that image
+     */
+    public function resolveContentThumbnail(Content $content): ?array
+    {
+        try {
+            $imageField = $this->getThumbnailImageField($content);
+        } catch (Exception $e) {
+            return null;
+        }
+
+        if ($imageField === null || $this->imageFieldType->isEmptyValue($imageField->value)) {
+            return null;
+        }
+
+        $thumbnailVariation = $this->variationHandler->getVariation($imageField, $content->versionInfo, self::THUMBNAIL_VARIATION_IDENTIFIER);
+
+        return [
+            'uri' => $thumbnailVariation->uri,
+            'width' => $thumbnailVariation->width,
+            'height' => $thumbnailVariation->height,
+            'alternativeText' => $imageField->value->alternativeText,
+        ];
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function getThumbnailImageField(Content $content): Field
+    {
+        foreach ($content->getFieldsByLanguage() as $field) {
+            if ($field->fieldTypeIdentifier === 'ezimage') {
+                return $field;
+            } elseif ($field->fieldTypeIdentifier === 'ezimageasset') {
+                $assetContent = $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId));
+
+                return $this->assetMapper->getAssetField($assetContent);
+            } elseif ($field->fieldTypeIdentifier === 'ezobjectrelation') {
+                $relatedContent = $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId));
+
+                return $this->getThumbnailImageField($relatedContent);
+            }
+        }
+
+        foreach ($content->getFieldsByLanguage() as $field) {
+            if ($field->fieldTypeIdentifier === 'ezobjectrelation') {
+                $relatedContent = $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId));
+
+                return $this->getThumbnailImageField($relatedContent);
+            }
+        }
+
+        throw new Exception("Content doesn't have an image compatible field");
+    }
+}

--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -72,12 +72,15 @@ class DomainContentResolver
     /**
      * Resolves a domain content item by id, and checks that it is of the requested type.
      *
-     * @param \Overblog\GraphQLBundle\Definition\Argument $args
-     * @param $contentTypeIdentifier
+     * @param \Overblog\GraphQLBundle\Definition\Argument|array $args
+     * @param string|null $contentTypeIdentifier
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
+     *
+     * @throws \GraphQL\Error\UserError if $contentTypeIdentifier was specified, and the loaded item's type didn't match it
+     * @throws \GraphQL\Error\UserError if no argument was provided
      */
-    public function resolveDomainContentItem(Argument $args, $contentTypeIdentifier)
+    public function resolveDomainContentItem($args, $contentTypeIdentifier)
     {
         if (isset($args['id'])) {
             $criterion = new Query\Criterion\ContentId($args['id']);
@@ -93,7 +96,7 @@ class DomainContentResolver
 
         $contentType = $this->contentTypeLoader->load($content->contentInfo->contentTypeId);
 
-        if ($contentType->identifier !== $contentTypeIdentifier) {
+        if (null !== $contentTypeIdentifier && $contentType->identifier !== $contentTypeIdentifier) {
             throw new UserError("Content {$content->contentInfo->id} is not of type '$contentTypeIdentifier'");
         }
 

--- a/src/GraphQL/Resolver/LocationResolver.php
+++ b/src/GraphQL/Resolver/LocationResolver.php
@@ -8,6 +8,14 @@ namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\Exception\ArgumentsException;
+use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\LocationLoader;
+use EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQuerySortByMapper;
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
+use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 
 /**
  * @internal
@@ -24,17 +32,37 @@ class LocationResolver
      */
     private $contentService;
 
-    public function __construct(LocationService $locationService, ContentService $contentService)
-    {
+    /**
+     * @var \EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\LocationLoader
+     */
+    private $locationLoader;
+
+    /**
+     * @var \EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQuerySortByMapper
+     */
+    private $sortMapper;
+
+    public function __construct(
+        LocationService $locationService,
+        ContentService $contentService,
+        LocationLoader $locationLoader,
+        SearchQuerySortByMapper $sortMapper
+    ) {
         $this->locationService = $locationService;
         $this->contentService = $contentService;
+        $this->locationLoader = $locationLoader;
+        $this->sortMapper = $sortMapper;
     }
 
     public function resolveLocation($args)
     {
-        if (isset($args['id'])) {
-            return $this->locationService->loadLocation($args['id']);
+        if (isset($args['locationId'])) {
+            return $this->locationLoader->findById($args['locationId']);
+        } elseif (isset($args['remoteId'])) {
+            return $this->locationLoader->findByRemoteId($args['remoteId']);
         }
+
+        throw new ArgumentsException('Requires one and only one of remoteId or locationId');
     }
 
     public function resolveLocationsByContentId($contentId)
@@ -49,12 +77,32 @@ class LocationResolver
         return $this->locationService->loadLocation($locationId);
     }
 
-    public function resolveLocationChildren($args)
+    /**
+     * @param Argument $args
+     *
+     * @return Connection
+     */
+    public function resolveLocationChildren($locationId, Argument $args): Connection
     {
-        if (isset($args['id'])) {
-            return $this->locationService->loadLocationChildren(
-                $this->locationService->loadLocation($args['id'])
-            )->locations;
-        }
+        $args['locationId'] = $locationId;
+        $sortClauses = isset($args['sortBy']) ? $this->sortMapper->mapInputToSortClauses($args['sortBy']) : [];
+
+        $query = new LocationQuery([
+            'filter' => new Query\Criterion\ParentLocationId($args['locationId']),
+            'sortClauses' => $sortClauses,
+        ]);
+        $paginator = new Paginator(function ($offset, $limit) use ($query) {
+            $query->offset = $offset;
+            $query->limit = $limit ?? 10;
+
+            return $this->locationLoader->find($query);
+        });
+
+        return $paginator->auto(
+            $args,
+            function () use ($query) {
+                return $this->locationLoader->count($query);
+            }
+        );
     }
 }

--- a/src/GraphQL/Resolver/LocationResolver.php
+++ b/src/GraphQL/Resolver/LocationResolver.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\Exception\ArgumentsException;
 use EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\LocationLoader;
 use EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQuerySortByMapper;
+use EzSystems\EzPlatformGraphQL\GraphQL\Relay\PageAwareConnection;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
@@ -86,7 +87,7 @@ class LocationResolver
      *
      * @return Connection
      */
-    public function resolveLocationChildren($locationId, Argument $args): Connection
+    public function resolveLocationChildren($locationId, Argument $args): PageAwareConnection
     {
         $args['locationId'] = $locationId;
         $sortClauses = isset($args['sortBy']) ? $this->sortMapper->mapInputToSortClauses($args['sortBy']) : [];
@@ -103,11 +104,14 @@ class LocationResolver
             return $this->locationLoader->find($query);
         });
 
-        return $paginator->auto(
-            $args,
-            function () use ($query) {
-                return $this->locationLoader->count($query);
-            }
+        return PageAwareConnection::fromConnection(
+            $paginator->auto(
+                $args,
+                function () use ($query) {
+                    return $this->locationLoader->count($query);
+                }
+            ),
+            $args
         );
     }
 

--- a/src/Resources/config/graphql/Content.types.yml
+++ b/src/Resources/config/graphql/Content.types.yml
@@ -23,6 +23,10 @@ Content:
             currentVersionNo:
                 type: "Int"
                 description: "Version number of the published version, or 1 for a newly created draft."
+            currentVersion:
+                type: "Version"
+                description: "The currently published version"
+                resolve: "@=resolver('CurrentVersion', [value])"
             versions:
                 type: "[Version]"
                 description: "All content versions."

--- a/src/Resources/config/graphql/DomainContent.types.yml
+++ b/src/Resources/config/graphql/DomainContent.types.yml
@@ -27,6 +27,8 @@ DomainContent:
             _url:
                 description: "The content item's url alias, based on the main location."
                 type: String
+            _thumbnail:
+                type: Thumbnail
         resolveType: "@=resolver('DomainContentType', [value])"
 
 AbstractDomainContent:
@@ -68,6 +70,9 @@ AbstractDomainContent:
                 description: "The content item's url alias, based on the main location."
                 type: String
                 resolve: "@=resolver('MainUrlAlias', [value])"
+            _thumbnail:
+                type: Thumbnail
+                resolve: "@=resolver('ContentThumbnail', [value])"
 
 DomainContentTypeGroup:
     type: object
@@ -104,4 +109,20 @@ DomainContentByIdentifierConnection:
             sliceSize:
                 type: Int!
             orderBy:
+                type: String
+
+Thumbnail:
+    type: object
+    config:
+        fields:
+            uri:
+                type: String
+                description: "The image's URI (example: 'https://example.com/var/site/storage/images/_aliases/small/9/8/1/0/189-1-eng-GB/image.png')"
+            width:
+                type: Int
+                description: "The width as number of pixels (example: 320)"
+            height:
+                type: Int
+                description: "The height as number of pixels (example: 200)"
+            alternativeText:
                 type: String

--- a/src/Resources/config/graphql/Location.types.yml
+++ b/src/Resources/config/graphql/Location.types.yml
@@ -82,3 +82,14 @@ LocationConnection:
                 type: String
             totalCount:
                 type: Int
+            pages:
+                type: "[ConnectionPage]"
+
+ConnectionPage:
+    type: object
+    config:
+        fields:
+            number:
+                type: Int
+            cursor:
+                type: String

--- a/src/Resources/config/graphql/Location.types.yml
+++ b/src/Resources/config/graphql/Location.types.yml
@@ -80,3 +80,5 @@ LocationConnection:
                 type: Int!
             orderBy:
                 type: String
+            totalCount:
+                type: Int

--- a/src/Resources/config/graphql/Location.types.yml
+++ b/src/Resources/config/graphql/Location.types.yml
@@ -49,9 +49,12 @@ Location:
                     custom:
                         type: "Boolean"
                 resolve: "@=resolver('LocationUrlAliases', [value, args])"
-            content:
+            contentInfo:
                 type: Content
                 resolve: "@=value.getContentInfo()"
+            content:
+                type: DomainContent
+                resolve: "@=resolver('DomainContentItem', [{id: value.id}, null])"
 
 LocationSortByOptions:
     type: enum

--- a/src/Resources/config/graphql/Location.types.yml
+++ b/src/Resources/config/graphql/Location.types.yml
@@ -54,7 +54,7 @@ Location:
                 resolve: "@=value.getContentInfo()"
             content:
                 type: DomainContent
-                resolve: "@=resolver('DomainContentItem', [{id: value.id}, null])"
+                resolve: "@=resolver('DomainContentItem', [{id: value.contentId}, null])"
 
 LocationSortByOptions:
     type: enum

--- a/src/Resources/config/graphql/Location.types.yml
+++ b/src/Resources/config/graphql/Location.types.yml
@@ -49,8 +49,9 @@ Location:
                     custom:
                         type: "Boolean"
                 resolve: "@=resolver('LocationUrlAliases', [value, args])"
-            contentInfo:
+            content:
                 type: Content
+                resolve: "@=value.getContentInfo()"
 
 LocationSortByOptions:
     type: enum

--- a/src/Resources/config/graphql/Location.types.yml
+++ b/src/Resources/config/graphql/Location.types.yml
@@ -38,11 +38,44 @@ Location:
                 type: "Int"
                 description: "Depth location has in the location tree"
             children:
-                type: "[Location]"
-                resolve: "@=resolver('LocationChildren', [{'id': value.id}])"
+                type: "LocationConnection"
+                resolve: "@=resolver('LocationChildren', [{locationId: value.id}, args])"
+                argsBuilder: 'Relay::Connection'
+                args:
+                    sortBy: { type: '[LocationSortByOptions]', description: 'A sort clause, or array of clauses. Add _desc after a clause to reverse it' }
             urlAliases:
                 type: "[LocationUrlAlias]"
                 args:
                     custom:
                         type: "Boolean"
                 resolve: "@=resolver('LocationUrlAliases', [value, args])"
+            contentInfo:
+                type: Content
+
+LocationSortByOptions:
+    type: enum
+    inherits: ["SortByOptions"]
+    config:
+        values:
+            _depth:
+                value: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Depth'
+            _locationId:
+                value: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Id'
+            _isMainLocation:
+                value: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\IsMainLocation'
+            _path:
+                value: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path'
+            _priority:
+                value: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority'
+            _visibility:
+                value: '\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Visibility'
+
+LocationConnection:
+    type: relay-connection
+    config:
+        nodeType: Location
+        connectionFields:
+            sliceSize:
+                type: Int!
+            orderBy:
+                type: String

--- a/src/Resources/config/graphql/Repository.types.yml
+++ b/src/Resources/config/graphql/Repository.types.yml
@@ -3,6 +3,16 @@ Repository:
     config:
         description: "eZ Platform repository"
         fields:
+            location:
+                type: "Location"
+                args:
+                    locationId:
+                        description: "A location id"
+                        type: "Int"
+                    remoteId:
+                        description: "A location remote id"
+                        type: "Int"
+                resolve: "@=resolver('Location', [args])"
             contentType:
                 type: "ContentType"
                 args:

--- a/src/Resources/config/graphql/Version.types.yml
+++ b/src/Resources/config/graphql/Version.types.yml
@@ -22,6 +22,9 @@ Version:
                 type: "DateTime"
             creatorId:
                 type: "Int"
+            creator:
+                type: "User"
+                resolve: "@=resolver('UserById', [value.creatorId])"
             status:
                 type: "Int"
             initialLanguageCode:

--- a/src/Resources/config/services/data_loaders.yml
+++ b/src/Resources/config/services/data_loaders.yml
@@ -29,3 +29,8 @@ services:
             - '@EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\RepositoryContentTypeLoader'
 
     EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\ContentTypeLoader: '@EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\CachedContentTypeLoader'
+
+    EzSystems\EzPlatformGraphQL\GraphQL\DataLoader\SearchLocationLoader:
+        arguments:
+            $searchService: '@ezpublish.siteaccessaware.service.search'
+            $locationService: '@ezpublish.siteaccessaware.service.location'

--- a/src/Resources/config/services/resolvers.yml
+++ b/src/Resources/config/services/resolvers.yml
@@ -23,6 +23,7 @@ services:
             - { name: overblog_graphql.resolver, alias: "ContentByType", method: "findContentByType" }
             - { name: overblog_graphql.resolver, alias: "ContentRelations", method: "findContentRelations" }
             - { name: overblog_graphql.resolver, alias: "ContentReverseRelations", method: "findContentReverseRelations" }
+            - { name: overblog_graphql.resolver, alias: "CurrentVersion", method: "resolveCurrentVersion" }
         arguments:
             $contentService: '@ezpublish.siteaccessaware.service.content'
             $searchService: '@ezpublish.siteaccessaware.service.search'

--- a/src/Resources/config/services/resolvers.yml
+++ b/src/Resources/config/services/resolvers.yml
@@ -40,6 +40,13 @@ services:
         arguments:
             $repository: "@ezpublish.siteaccessaware.repository"
 
+    EzSystems\EzPlatformGraphQL\GraphQL\Resolver\ContentThumbnailResolver:
+        tags:
+            - { name: overblog_graphql.resolver, alias: "ContentThumbnail", method: "resolveContentThumbnail" }
+        arguments:
+            $imageFieldType: "@ezpublish.fieldType.ezimage"
+            $variationHandler: "@ezpublish.fieldType.ezimage.variation_service"
+
     EzSystems\EzPlatformGraphQL\GraphQL\Mutation\UploadFiles:
         arguments:
             $repository: '@ezpublish.siteaccessaware.repository'

--- a/src/Resources/config/services/services.yml
+++ b/src/Resources/config/services/services.yml
@@ -10,6 +10,5 @@ services:
         tags:
             -  { name: console.command }
 
-    EzSystems\EzPlatformGraphQL\GraphQL\TypeDefinition\ContentTypeMapper: ~
-
-    EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\SearchQueryMapper: ~
+    EzSystems\EzPlatformGraphQL\GraphQL\InputMapper\:
+        resource: '../../GraphQL/InputMapper'


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30726
> Target version: 1.1 (merges to master for 2.0 release without any issue)

- Adds `Repository.location: Location` field that returns a location by id.
- Adds `Location.children` that returns a connection with the location's children
- Adds `Location.content: Content`
- Adds `ContentInfo.currentVersion: Version`
- Adds `Version.creator: User`
- Adds `Content._thumbnail: Thumbnail`

Also adds page number based pagination support using a new connection field, `LocationConnection.pages`.

Example:
```
{
  _repository {
    location(locationId: 2) {
      pathString
      children {
        pages {
          number
          cursor
        }
        edges {
          node {
            content {
              name
              currentVersion {
                creator {
                  name
                }
              }
            }
          }
        }
      }
    }
  }
}
```

### TODO
- [x] Define a dedicated alias for thumbnails (200x200 pixels)
- [x] Change `Location.id` to be an `ID`, and add `Location.locationId` with the auto-increment id.