### PR TITLE
EZP-30846: Dropped deprecated Symfony\Component\Config\Definition\Builder\TreeBuilder::root method calls

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,13 +21,6 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ezplatform_graphql');
-
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
-
-        return $treeBuilder;
+        return new TreeBuilder('ezplatform_graphql');
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30846

## Description 

Since Symfony 4.3 configuration root name should be passed via constructor instead of using "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method.

More information:
* https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes
* https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config