### PR TITLE
Added auto-configuration of types paths

### DIFF
--- a/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
+++ b/src/DependencyInjection/EzSystemsEzPlatformGraphQLExtension.php
@@ -57,6 +57,10 @@ class EzSystemsEzPlatformGraphQLExtension extends Extension implements PrependEx
             'type' => 'yaml',
             'dir' => $container->getParameter('ezplatform.graphql.package.root_dir') . self::PACKAGE_SCHEMA_DIR_PATH,
         ];
+        $graphQLConfig['definitions']['mappings']['types'][] = [
+            'type' => 'yaml',
+            'dir' => $container->getParameter('kernel.project_dir') . self::SCHEMA_DIR_PATH,
+        ];
         $container->prependExtensionConfig('overblog_graphql', $graphQLConfig);
     }
 


### PR DESCRIPTION
In the previous overblog/graphql version, paths with types were auto-discovered.
This change makes the paths declaration explicit.