### PR TITLE
Fix EZP-30957: avoid exceptions on content types not in the generated schema

### DIFF
--- a/src/DependencyInjection/GraphQL/YamlSchemaProvider.php
+++ b/src/DependencyInjection/GraphQL/YamlSchemaProvider.php
@@ -37,6 +37,7 @@ class YamlSchemaProvider implements SchemaProvider
             'query' => $this->getQuerySchema(),
             'mutation' => $this->getMutationSchema(),
             'resolver_maps' => [UploadMap::class],
+            'types' => ['UntypedContent'],
         ];
     }
 

--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -154,9 +154,13 @@ class DomainContentResolver
 
     public function resolveDomainContentType(Content $content)
     {
-        return $this->makeDomainContentTypeName(
+        $typeName = $this->makeDomainContentTypeName(
             $this->contentTypeLoader->load($content->contentInfo->contentTypeId)
         );
+
+        return  ($this->typeResolver->hasSolution($typeName))
+            ? $typeName
+            : 'UntypedContent';
     }
 
     private function makeDomainContentTypeName(ContentType $contentType)

--- a/src/Resources/config/graphql/DomainContent.types.yml
+++ b/src/Resources/config/graphql/DomainContent.types.yml
@@ -74,6 +74,19 @@ AbstractDomainContent:
                 type: Thumbnail
                 resolve: "@=resolver('ContentThumbnail', [value])"
 
+UntypedContent:
+    type: object
+    inherits:
+        - AbstractDomainContent
+    config:
+        interfaces:
+            - DomainContent
+            - Node
+        fields:
+            reason:
+                type: String
+                resolve: "This content type isn't part of the schema."
+
 DomainContentTypeGroup:
     type: object
     config:


### PR DESCRIPTION
After a content type has been added, but before the schema has been generated, trying to list
a location's sub-items that contain one of those items will error out. The typeResolver of the
DomainContent interface will return for items of those types a name that doesn't exist in the schema.

To work around that, content items of types that don't exist in the schema are mapped to an "anonymous" type, "UntypedContent". It has the properties shared by all content items (`_url`, `_name`, `thumb` etc, but not the fields.

### TODO
- [x] ~~Consider renaming the type. `AnonymousContent`~~ (done, to `UntypedContent`)?
- [x] Rebase against the 1.x branch as it is also affected