### PR TITLE
Added a language argument on content fields

### DIFF
--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -132,9 +132,9 @@ class DomainContentResolver
         return isset($aliases[0]->path) ? $aliases[0]->path : null;
     }
 
-    public function resolveDomainFieldValue(Content $content, $fieldDefinitionIdentifier)
+    public function resolveDomainFieldValue(Content $content, $fieldDefinitionIdentifier, $args)
     {
-        return Field::fromField($content->getField($fieldDefinitionIdentifier));
+        return Field::fromField($content->getField($fieldDefinitionIdentifier, $args['language'] ?? null));
     }
 
     public function resolveDomainRelationFieldValue(Field $field, $multiple = false)

--- a/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
+++ b/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
@@ -33,6 +33,11 @@ class AddFieldValueToDomainContent extends BaseWorker implements Worker
             $this->typeName($args),
             new Input\Field($this->fieldName($args), $definition['type'], $definition)
         );
+        $schema->addArgToField(
+            $this->typeName($args),
+            $this->fieldName($args),
+            new Input\Arg('language', 'RepositoryLanguage')
+        );
     }
 
     private function getDefinition(FieldDefinition $fieldDefinition)


### PR DESCRIPTION
Gives more flexibility when querying multilingual content. As long as the current siteaccess is configured with several (or all) languages, multiple translations of each field can be obtained at once.

![image](https://user-images.githubusercontent.com/235928/65379453-7ff76380-dcc8-11e9-9c20-1eadd2675727.png)
