### PR TITLE
[Fix] Keeping the backoffice order in the GraphQL result of the relation list

### DIFF
--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -149,7 +149,16 @@ class DomainContentResolver
             ['filter' => new Query\Criterion\ContentId($destinationContentIds)]
         ));
 
-        return $multiple ? $contentItems : $contentItems[0] ?? null;
+        if ($multiple) {
+            return array_map(
+                function ($contentId) use ($contentItems) {
+                    return $contentItems[array_search($contentId, array_column($contentItems, 'id'))];
+                },
+                $destinationContentIds
+            );
+        }
+
+        return $contentItems[0] ?? null;
     }
 
     public function resolveDomainContentType(Content $content)


### PR DESCRIPTION
## This PR is a fix for relationlist.
In the backoffice, I have a relationlist with a specific order. I hope to recover my relationlist with the same order in the result of my GraphQL query.

### Before PR
![ez-relationlist-graphql](https://user-images.githubusercontent.com/3796755/65669751-68133d00-e044-11e9-9319-c9fdf0419c2d.png)

### After PR
![ez-relationlist-graphql-after-pr](https://user-images.githubusercontent.com/3796755/65669921-a90b5180-e044-11e9-826e-ae308ea9054d.png)