### PR TITLE
Added the FieldDefinition InputMapper API

### DIFF
--- a/src/DependencyInjection/Compiler/FieldInputHandlersPass.php
+++ b/src/DependencyInjection/Compiler/FieldInputHandlersPass.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
 
 use EzSystems\EzPlatformGraphQL\GraphQL\Resolver\DomainContentMutationResolver;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\ConfigurableFieldDefinitionInputMapper;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\FieldDefinition\AddFieldDefinitionToDomainContentMutation;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -48,6 +49,6 @@ class FieldInputHandlersPass implements CompilerPassInterface
         }
 
         $container->findDefinition(DomainContentMutationResolver::class)->setArgument('$fieldInputHandlers', $handlers);
-        $container->findDefinition(AddFieldDefinitionToDomainContentMutation::class)->setArgument('$typesInputMap', $typesMapping);
+        $container->findDefinition(ConfigurableFieldDefinitionInputMapper::class)->setArgument('$typesMap', $typesMapping);
     }
 }

--- a/src/Resources/config/services/schema.yml
+++ b/src/Resources/config/services/schema.yml
@@ -42,10 +42,18 @@ services:
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\RelationFieldDefinitionMapper:
         decorates: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
         arguments:
-            $contentTypeService: '@ezpublish.siteaccessaware.service.content_type'
+            #$contentTypeService: '@ezpublish.siteaccessaware.service.content_type'
             $innerMapper: '@EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\RelationFieldDefinitionMapper.inner'
 
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\SelectionFieldDefinitionMapper:
         decorates: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
         arguments:
             $innerMapper: '@EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\SelectionFieldDefinitionMapper.inner'
+
+    EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\ConfigurableFieldDefinitionInputMapper:
+        decorates: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionInputMapper
+        arguments:
+            $innerMapper: '@EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\ConfigurableFieldDefinitionInputMapper.inner'
+
+    EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionInputMapper:
+        class: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\DefaultFieldDefinitionInputMapper

--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionInputMapper.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionInputMapper.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+class ConfigurableFieldDefinitionInputMapper implements FieldDefinitionInputMapper
+{
+    /**
+     * @var array
+     * Map of ez field type identifier to a GraphQL type
+     */
+    private $typesMap;
+
+    /**
+     * @var \EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionInputMapper
+     */
+    private $innerMapper;
+
+    public function __construct(FieldDefinitionInputMapper $innerMapper, $typesMap = [])
+    {
+        $this->typesMap = $typesMap;
+        $this->innerMapper = $innerMapper;
+    }
+
+    public function mapToFieldValueInputType(ContentType $contentType, FieldDefinition $fieldDefinition): ?string
+    {
+        return $this->typesMap[$fieldDefinition->fieldTypeIdentifier]
+            ?? $this->innerMapper->mapToFieldValueInputType($contentType, $fieldDefinition);
+    }
+}

--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/DefaultFieldDefinitionInputMapper.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/DefaultFieldDefinitionInputMapper.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+class DefaultFieldDefinitionInputMapper implements FieldDefinitionInputMapper
+{
+    public function mapToFieldValueInputType(ContentType $contentType, FieldDefinition $fieldDefinition): ?string
+    {
+        return 'String';
+    }
+}

--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/FieldDefinitionInputMapper.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/FieldDefinitionInputMapper.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
+/**
+ * Maps a Field Definition to its GraphQL components for input (mutations).
+ */
+interface FieldDefinitionInputMapper
+{
+    public function mapToFieldValueInputType(ContentType $contentType, FieldDefinition $fieldDefinition): ?string;
+}

--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/SelectionFieldDefinitionMapper.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/SelectionFieldDefinitionMapper.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 
 class SelectionFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper

--- a/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
+++ b/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
@@ -28,18 +28,18 @@ class AddFieldValueToDomainContent extends BaseWorker implements Worker
 
     public function work(Builder $schema, array $args)
     {
-        $definition = $this->getDefinition($args['FieldDefinition']);
+        $definition = $this->getDefinition($args);
         $schema->addFieldToType(
             $this->typeName($args),
             new Input\Field($this->fieldName($args), $definition['type'], $definition)
         );
     }
 
-    private function getDefinition(FieldDefinition $fieldDefinition)
+    private function getDefinition(array $args)
     {
         return [
-            'type' => $this->fieldDefinitionMapper->mapToFieldValueType($fieldDefinition),
-            'resolve' => $this->fieldDefinitionMapper->mapToFieldValueResolver($fieldDefinition),
+            'type' => $this->fieldDefinitionMapper->mapToFieldValueType($args['FieldDefinition']),
+            'resolve' => $this->fieldDefinitionMapper->mapToFieldValueResolver($args['FieldDefinition']),
         ];
     }
 


### PR DESCRIPTION
Replaces the flat field type identifier => GraphQL type mapping that existed with an architecture similar to the `FieldDefinitionMapper`. The former mapping is handled by the `ConfigurableFieldDefinitionInputMapper`, and the default (String) by the `DefaultFieldDefinitionInputMapper`.

### TODO
- [ ] Try to find a backward compatible way to add this to `FieldDefinitionMapper` instead of creating a new, very similar, interface.