### PR TITLE
More deprecations in input_type configuration

### DIFF
--- a/src/DependencyInjection/Compiler/FieldInputHandlersPass.php
+++ b/src/DependencyInjection/Compiler/FieldInputHandlersPass.php
@@ -27,7 +27,6 @@ class FieldInputHandlersPass implements CompilerPassInterface
         $taggedServices = $container->findTaggedServiceIds('ezplatform_graphql.fieldtype_input_handler');
 
         $handlers = [];
-        $typesMapping = [];
         foreach ($taggedServices as $id => $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['fieldtype'])) {
@@ -36,18 +35,10 @@ class FieldInputHandlersPass implements CompilerPassInterface
                     );
                 }
 
-                if (!isset($tag['inputType'])) {
-                    throw new \InvalidArgumentException(
-                        "The ezplatform_graphql.fieldtype_input_handler tag requires an 'inputType' property set to the GraphQL input type it uses"
-                    );
-                }
-
                 $handlers[$tag['fieldtype']] = new Reference($id);
-                $typesMapping[$tag['fieldtype']] = $tag['inputType'];
             }
         }
 
         $container->findDefinition(DomainContentMutationResolver::class)->setArgument('$fieldInputHandlers', $handlers);
-        $container->findDefinition(AddFieldDefinitionToDomainContentMutation::class)->setArgument('$typesInputMap', $typesMapping);
     }
 }

--- a/src/DependencyInjection/Compiler/InputTypesMappingPass.php
+++ b/src/DependencyInjection/Compiler/InputTypesMappingPass.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
+
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\ConfigurableFieldDefinitionMapper;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Processes the deprecated inputType attribute of the ezplatform_graphql.fieldtype_input_handler service tag.
+ *
+ * The value is added to the ezplatform_graphql.schema.content.mapping.field_definition_type as the input_type
+ * configuration key.
+ *
+ * Since the FieldDefinitionMapper chain doesn't expose mapToFieldValueInput type yet,
+ * the ConfigurableFieldDefinitionMapper is then tagged for each fieldtype configured with input_type so that
+ * it is used by AddFieldDefinitionToDomainContentMutation.
+ *
+ * @deprecated will be removed in ezplatform-graphql 2.0.
+ */
+final class InputTypesMappingPass implements CompilerPassInterface
+{
+    private const INPUT_HANDLER_TAG = 'ezplatform_graphql.fieldtype_input_handler';
+    private const INPUT_MAPPER_TAG = 'ezplatform_graphql.field_definition_input_mapper';
+    private const PARAM = 'ezplatform_graphql.schema.content.mapping.field_definition_type';
+
+    public function process(ContainerBuilder $container)
+    {
+        $mappingConfiguration = $container->getParameter(self::PARAM);
+        foreach ($container->findTaggedServiceIds(self::INPUT_HANDLER_TAG) as $id => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['fieldtype'])) {
+                    throw new \InvalidArgumentException(
+                        sprintf(
+                            "The %s tag requires a 'fieldtype' property set to the Field Type's identifier",
+                            self::INPUT_HANDLER_TAG
+                        )
+                    );
+                }
+
+                if (isset($tag['inputType'])) {
+                    @trigger_error(
+                        sprintf(
+                            "The 'inputType' service tag attribute on %s is deprecated, and won't work anymore in ezplatform-graphql 2.0. Use the %s container parameter.",
+                            $id,
+                            self::PARAM
+                        ),
+
+                        E_USER_DEPRECATED
+                    );
+                    $mappingConfiguration[$tag['fieldtype']]['input_type'] = $tag['inputType'];
+                }
+            }
+        }
+
+        $container->setParameter(self::PARAM, $mappingConfiguration);
+
+        $configurableMapperDefinition = $container->getDefinition(ConfigurableFieldDefinitionMapper::class);
+        foreach ($mappingConfiguration as $fieldtype => $configuration) {
+            if (isset($configuration['input_type'])) {
+                $configurableMapperDefinition->addTag(self::INPUT_MAPPER_TAG, ['fieldtype' => $fieldtype]);
+            }
+        }
+    }
+}

--- a/src/EzSystemsEzPlatformGraphQLBundle.php
+++ b/src/EzSystemsEzPlatformGraphQLBundle.php
@@ -7,6 +7,7 @@
 namespace EzSystems\EzPlatformGraphQL;
 
 use EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -18,6 +19,7 @@ class EzSystemsEzPlatformGraphQLBundle extends Bundle
 
         $container->addCompilerPass(new Compiler\FieldDefinitionInputMappersPass());
         $container->addCompilerPass(new Compiler\FieldInputHandlersPass());
+        $container->addCompilerPass(new Compiler\InputTypesMappingPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
         $container->addCompilerPass(new Compiler\RichTextInputConvertersPass());
         $container->addCompilerPass(new Compiler\SchemaWorkersPass());
         $container->addCompilerPass(new Compiler\SchemaDomainIteratorsPass());

--- a/src/Resources/config/default_settings.yml
+++ b/src/Resources/config/default_settings.yml
@@ -3,33 +3,42 @@ parameters:
     ezauthor:
       value_type: "[AuthorFieldValue]"
       value_resolver: 'field.authors'
+      input_type: '[AuthorInput]'
     ezbinaryfile:
       definition_type: BinaryFieldDefinition
       value_type: BinaryFileFieldValue
+      input_type: BinaryFieldInput
     ezboolean:
       definition_type: CheckboxFieldDefinition
       value_type: Boolean
       value_resolver: 'field.bool'
+      input_type: Boolean
     ezcountry:
       definition_type: CountryFieldDefinition
       value_type: String
+      input_type: '[String]'
     ezdate:
       value_type: DateTime
       value_resolver: 'field.date'
+      input_type: DateFieldInput
     ezdatetime:
       value_type: DateTime
       value_resolver: 'field.value'
+      input_type: DateFieldInput
     ezemail:
       value_type: String
     ezfloat:
       definition_type: FloatFieldDefinition
       value_type: Float
       value_resolver: 'field.value'
+      input_type: Float
     ezgmaplocation:
       value_type: MapLocationFieldValue
+      input_type: 'MapLocationFieldInput'
     ezimage:
       definition_type: BinaryFieldDefinition
       value_type: ImageFieldValue
+      input_type: ImageFieldInput
     ezimageasset:
       value_type: ImageFieldValue
       value_resolver: 'resolver("DomainImageAssetFieldValue", [field])'
@@ -37,25 +46,34 @@ parameters:
       definition_type: IntegerFieldDefinition
       value_type: Int
       value_resolver: 'field.value'
+      input_type: Int
     ezkeyword:
       value_type: '[String]'
       value_resolver: 'field.values'
+      input_type: '[String]'
     ezmedia:
       definition_type: MediaFieldDefinition
       value_type: MediaFieldValue
+      input_type: MediaFieldInput
     ezobjectrelation:
       definition_type: RelationFieldDefinition
       value_type: RelationFieldValue
+      input_type: Int
     ezobjectrelationlist:
       definition_type: RelationListFieldDefinition
       value_type: RelationListFieldValue
+      input_type: '[Int]'
     ezrichtext:
       value_type: RichTextFieldValue
+      input_type: RichTextFieldInput
     ezselection:
       definition_type: SelectionFieldDefinition
+      input_type: '[Int]'
     ezstring:
       definition_type: TextLineFieldDefinition
       value_type: String
     eztext:
       definition_type: TextBlockFieldDefinition
       value_type: String
+    ezurl:
+      input_type: UrlFieldInput

--- a/src/Resources/config/services/mutations.yml
+++ b/src/Resources/config/services/mutations.yml
@@ -15,103 +15,103 @@ services:
     arguments:
       $fieldType: '@ezpublish.fieldType.ezauthor'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezauthor', inputType: '[AuthorInput]' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezauthor' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\BinaryFile:
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezbinaryfile', inputType: BinaryFieldInput }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezbinaryfile' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Boolean:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezboolean'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezboolean', inputType: Boolean }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezboolean' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Country:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezcountry'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezcountry', inputType: '[String]' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezcountry' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Date:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Date'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezdate'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezdate', inputType: DateFieldInput }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezdate' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\DateAndTime:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Date'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezdatetime'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezdatetime', inputType: DateFieldInput }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezdatetime' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Float:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezfloat'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezfloat', inputType: Float }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezfloat' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Email:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezemail'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezemail', inputType: String }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezemail' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Image:
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezimage', inputType: ImageFieldInput }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezimage' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Integer:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezinteger'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezinteger', inputType: Int }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezinteger' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\ISBN:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezisbn'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezisbn', inputType: String }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezisbn' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Keyword:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezkeyword'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezkeyword', inputType: '[String]' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezkeyword' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\MapLocation:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezgmaplocation'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezgmaplocation', inputType: 'MapLocationFieldInput' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezgmaplocation' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Media:
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezmedia', inputType: MediaFieldInput }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezmedia' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Relation:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Relation'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezobjectrelation'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezobjectrelation', inputType: Int }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezobjectrelation' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RelationList:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RelationList'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezobjectrelationlist'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezobjectrelationlist', inputType: '[Int]' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezobjectrelationlist' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText:
     arguments:
@@ -119,7 +119,7 @@ services:
         html: '@EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText\HtmlRichTextConverter'
         markdown: '@EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText\MarkdownRichTextConverter'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezrichtext', inputType: RichTextFieldInput }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezrichtext' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText\HtmlRichTextConverter:
     arguments:
@@ -138,25 +138,25 @@ services:
     arguments:
       $fieldType: '@ezpublish.fieldType.ezselection'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezselection', inputType: '[Int]' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezselection' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\TextBlock:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.eztext'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'eztext', inputType: 'String' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'eztext' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\TextLine:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezstring'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezstring', inputType: 'String' }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezstring' }
 
   EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\Url:
     class: 'EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezurl'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezurl', inputType: UrlFieldInput }
+      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezurl' }

--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapper.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapper.php
@@ -6,9 +6,10 @@
  */
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 
-class ConfigurableFieldDefinitionMapper implements FieldDefinitionMapper
+class ConfigurableFieldDefinitionMapper implements FieldDefinitionMapper, FieldDefinitionInputMapper
 {
     /**
      * @var array
@@ -31,6 +32,19 @@ class ConfigurableFieldDefinitionMapper implements FieldDefinitionMapper
     {
         return $this->typesMap[$fieldDefinition->fieldTypeIdentifier]['value_type']
             ?? $this->innerMapper->mapToFieldValueType($fieldDefinition);
+    }
+
+    public function mapToFieldValueInputType(ContentType $contentType, FieldDefinition $fieldDefinition): ?string
+    {
+        if (isset($this->typesMap[$fieldDefinition->fieldTypeIdentifier]['input_type'])) {
+            return $this->typesMap[$fieldDefinition->fieldTypeIdentifier]['input_type'];
+        }
+
+        if ($this->innerMapper instanceof FieldDefinitionInputMapper) {
+            return $this->innerMapper->mapToFieldValueType($fieldDefinition);
+        }
+
+        return null;
     }
 
     public function mapToFieldDefinitionType(FieldDefinition $fieldDefinition): ?string


### PR DESCRIPTION
> Continuation of https://github.com/ezsystems/ezplatform-graphql/pull/61

Completes the deprecations required by https://github.com/ezsystems/ezplatform-matrix-fieldtype/pull/20. The change should be fully forward compatible.

- Moved `inputType` attributes from built-in field types input handler services, and added them to the configuration.
- When the `inputType attribute` is set on an `ezplatform_graphql.fieldtype_input_handler` tag, add it to the configuration for that field type as `input_type`.
- For every `input_type` configuration, tag the `ConfigurableFieldDefinitionMapper` as `ezplatform_graphql.field_definition_input_mapper` for that fieldtype so that it gets injected into the worker for that field type
- Implemented `FieldDefinitionInputMapper` on `ConfigurableFieldDefinitionMapper` so that it can be used from the worker.