### PR TITLE
Fix mutation InputHandler field mapping for Image FieldType

### DIFF
--- a/src/GraphQL/Mutation/InputHandler/FieldType/Image.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/Image.php
@@ -22,8 +22,8 @@ class Image implements FieldTypeInputHandler
         $file = $input['file'];
 
         return new ImageFieldType\Value([
-            'alternativeText' => $fieldInput['alternativeText'] ?? '',
-            'fileName' => $file->getClientOriginalName(),
+            'alternativeText' => $input['alternativeText'] ?? '',
+            'fileName' => (!empty($input['name'])) ? $input['name'] : $file->getClientOriginalName(),
             'inputUri' => $file->getPathname(),
             'fileSize' => $file->getSize(),
         ]);


### PR DESCRIPTION
When uploading files through GraphQL mutation, alternativeText and name fields will not populate the new object attributes.