### PR TITLE
Add full query support for ezxmltext field type

### DIFF
--- a/src/GraphQL/Resolver/XmlTextResolver.php
+++ b/src/GraphQL/Resolver/XmlTextResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
+
+use DOMDocument;
+use eZ\Publish\Core\FieldType\XmlText\Converter\Html5 as Html5Converter;
+
+/**
+ * @internal
+ */
+class XmlTextResolver
+{
+    /**
+     * @var Html5Converter
+     */
+    private $xmlTextConverter;
+
+    public function __construct(Html5Converter $xmlTextConverter)
+    {
+        $this->xmlTextConverter = $xmlTextConverter;
+    }
+
+    public function xmlTextToHtml5(DOMDocument $document)
+    {
+        return $this->xmlTextConverter->convert($document);
+    }
+
+}

--- a/src/GraphQL/Resolver/XmlTextResolver.php
+++ b/src/GraphQL/Resolver/XmlTextResolver.php
@@ -4,7 +4,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use DOMDocument;
@@ -29,5 +28,4 @@ class XmlTextResolver
     {
         return $this->xmlTextConverter->convert($document);
     }
-
 }

--- a/src/Resources/config/default_settings.yaml
+++ b/src/Resources/config/default_settings.yaml
@@ -77,3 +77,5 @@ parameters:
       value_type: String
     ezurl:
       input_type: UrlFieldInput
+    ezxmltext:
+      value_type: XmlTextFieldValue

--- a/src/Resources/config/graphql/Field.types.yaml
+++ b/src/Resources/config/graphql/Field.types.yaml
@@ -260,3 +260,24 @@ SelectionFieldValue:
                 type: "String"
                 description: "String representation of the value"
                 resolve: "@=value"
+
+XmlTextFieldValue:
+    type: object
+    config:
+        fields:
+            text:
+                type: "String"
+                description: "String representation of the value"
+                resolve: "@=value"
+            xml:
+                type: "String"
+                description: "The raw ezxmltext xml"
+                resolve: "@=value"
+            plaintext:
+                type: "String"
+                description: "Plain text representation of the value, without tags. Warning: the text representation may not be perfect."
+                resolve: "@=value.xml.textContent"
+            html5:
+                type: "String"
+                description: "HTML5 representation."
+                resolve: "@=resolver('XmlTextToHtml5', [value.xml])"

--- a/src/Resources/config/services/resolvers.yaml
+++ b/src/Resources/config/services/resolvers.yaml
@@ -138,6 +138,12 @@ services:
         tags:
             - {name: overblog_graphql.resolver, alias: "SearchContentConnection", method: "searchContent"}
 
+    EzSystems\EzPlatformGraphQL\GraphQL\Resolver\XmlTextResolver:
+        arguments:
+            - "@ezpublish.fieldType.ezxmltext.converter.html5"
+        tags:
+            - { name: overblog_graphql.resolver, alias: "XmlTextToHtml5", method: "xmlTextToHtml5" }
+
     #
     # Object States
     #


### PR DESCRIPTION
This PR provides full query support for `ezxmltext` field types.

Modelled after the richtext field type, it offers these subtypes:

          text:
                type: "String"
                description: "String representation of the value"
            xml:
                type: "String"
                description: "The raw ezxmltext xml"
            plaintext:
                type: "String"
                description: "Plain text representation of the value, without tags. Warning: the text representation may not be perfect."
            html5:
                type: "String"
                description: "HTML5 representation."

Note: mutations are not in the scope of this PR.
