### PR TITLE
Dynamic schema

### DIFF
--- a/src/Command/HotGraphQLTypesCommand.php
+++ b/src/Command/HotGraphQLTypesCommand.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\EzPlatformGraphQL\Command;
+
+use Doctrine\DBAL\Schema\SchemaDiff;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use EzSystems\EzPlatformGraphQL\Schema\DynamicSchema\SchemaDiffBuilder;
+use EzSystems\EzPlatformGraphQL\Schema\Initializer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class HotGraphQLTypesCommand extends Command
+{
+    protected static $defaultName = 'app:hot-graphql-types';
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var \EzSystems\EzPlatformGraphQL\Schema\DynamicSchema\SchemaDiffBuilder */
+    private $schema;
+
+    /** @var \EzSystems\EzPlatformGraphQL\Schema\Worker[] */
+    private $workers;
+
+    public function __construct(ContentTypeService $contentTypeService, SchemaDiffBuilder $schemaBuilder, array $workers)
+    {
+        parent::__construct();
+        $this->contentTypeService = $contentTypeService;
+        $this->schema = $schemaBuilder;
+        $this->workers = $workers;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($input->getArgument('content-type'));
+
+        $this->hotLoadContentType($contentType);
+    }
+
+    private function hotLoadContentType(ContentType $contentType)
+    {
+        $contentTypeGroup = $contentType->getContentTypeGroups()[0];
+
+        // prepare iterators ?
+        $iterator = [
+            ['ContentTypeGroup' => $contentTypeGroup, 'ContentType' => $contentType],
+        ];
+
+        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
+            $iterator[] = ['ContentType' => $contentType, 'FieldDefinition' => $fieldDefinition];
+        }
+
+        $this->generateWithIterator($iterator);
+        dump($this->schema->getAddedTypes());
+    }
+
+    protected function configure()
+    {
+        $this
+            ->addArgument('content-type', InputArgument::REQUIRED)
+            ->setDescription("Hot-loads a content type into the GraphQL schema");
+    }
+
+    private function generateWithIterator($iterator)
+    {
+        foreach ($this->workers as $worker) {
+            if ($worker instanceof Initializer) {
+                $worker->init($this->schema);
+            }
+        }
+
+        foreach ($iterator as $arguments) {
+            foreach ($this->workers as $schemaWorker) {
+                if (!$schemaWorker->canWork($this->schema, $arguments)) {
+                    continue;
+                }
+                $schemaWorker->work($this->schema, $arguments);
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/SchemaWorkersTestPass.php
+++ b/src/DependencyInjection/Compiler/SchemaWorkersTestPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\DependencyInjection\Compiler;
+
+use App\Command\HotGraphQLTypesCommand;
+use EzSystems\EzPlatformGraphQL\Schema\Generator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class SchemaWorkersTestPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has(HotGraphQLTypesCommand::class)) {
+            return;
+        }
+
+        $generatorDefinition = $container->getDefinition(HotGraphQLTypesCommand::class);
+
+        $workers = [];
+        foreach ($container->findTaggedServiceIds('ezplatform_graphql.domain_schema_worker') as $id => $tags) {
+            $workers[] = new Reference($id);
+        }
+
+        $generatorDefinition->setArgument('$workers', $workers);
+        $container->setDefinition(HotGraphQLTypesCommand::class, $generatorDefinition);
+    }
+}

--- a/src/EzSystemsEzPlatformGraphQLBundle.php
+++ b/src/EzSystemsEzPlatformGraphQLBundle.php
@@ -19,6 +19,7 @@ class EzSystemsEzPlatformGraphQLBundle extends Bundle
         $container->addCompilerPass(new Compiler\FieldInputHandlersPass());
         $container->addCompilerPass(new Compiler\RichTextInputConvertersPass());
         $container->addCompilerPass(new Compiler\SchemaWorkersPass());
+        $container->addCompilerPass(new Compiler\SchemaWorkersTestPass());
         $container->addCompilerPass(new Compiler\SchemaDomainIteratorsPass());
     }
 }

--- a/src/Resources/config/services/schema.yaml
+++ b/src/Resources/config/services/schema.yaml
@@ -56,6 +56,10 @@ services:
         arguments:
             - '@overblog_graphql.type_resolver'
 
+    EzSystems\EzPlatformGraphQL\Schema\Builder: '@EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder'
+
+    EzSystems\EzPlatformGraphQL\Schema\DynamicSchema\SchemaDiffBuilder: ~
+
     EzSystems\EzPlatformGraphQL\Schema\DynamicSchema\EventSubscriber\PreExecutorSubscriber:
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Resources/config/services/schema.yaml
+++ b/src/Resources/config/services/schema.yaml
@@ -49,3 +49,15 @@ services:
         decorates: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
         arguments:
             $innerMapper: '@EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\SelectionFieldDefinitionMapper.inner'
+
+    EzSystems\EzPlatformGraphQL\Schema\DynamicSchema\ConfigProcessor:
+        tags:
+            - { name: overblog_graphql.definition_config_processor, priority: 512 }
+        arguments:
+            - '@overblog_graphql.type_resolver'
+
+    EzSystems\EzPlatformGraphQL\Schema\DynamicSchema\EventSubscriber\PreExecutorSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }
+        arguments:
+            $typeResolver: '@overblog_graphql.type_resolver'

--- a/src/Schema/DynamicSchema/ConfigProcessor.php
+++ b/src/Schema/DynamicSchema/ConfigProcessor.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+
+namespace EzSystems\EzPlatformGraphQL\Schema\DynamicSchema;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Definition\ConfigProcessor\ConfigProcessorInterface;
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
+use Overblog\GraphQLBundle\Definition\LazyConfig;
+use Overblog\GraphQLBundle\Resolver\FluentResolverInterface;
+
+final class ConfigProcessor implements ConfigProcessorInterface
+{
+    /** @var \Overblog\GraphQLBundle\Resolver\FluentResolverInterface */
+    private $typeResolver;
+
+    /** @var \Overblog\GraphQLBundle\Definition\GlobalVariables */
+    private $globalVariables;
+
+    public function __construct(FluentResolverInterface $typeResolver, GlobalVariables $globalVariables)
+    {
+        $this->typeResolver = $typeResolver;
+        $this->globalVariables = $globalVariables;
+    }
+
+    private function addField(array $fields)
+    {
+        $resolverArguments = new Argument(['id' => 56]);
+        $globalVariables = $this->globalVariables;
+        $fields['_hot'] = [
+            'type' => $this->typeResolver->getSolution('HotContent'),
+            'args' => [],
+            'resolve' => function ($value, $args, $context, ResolveInfo $info) use ($globalVariables, $resolverArguments) {
+                return $globalVariables->get('resolverResolver')->resolve(["DomainContentItem", [0 => $resolverArguments, 1 => "hot"]]);
+            },
+            'description' => '',
+            'deprecationReason' => null
+        ];
+
+        return $fields;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(LazyConfig $lazyConfig)
+    {
+        $lazyConfig->addPostLoader(function ($config) {
+            if ($config['name'] === 'DomainGroupContent') {
+                if (isset($config['fields']) && \is_callable($config['fields'])) {
+                    $config['fields'] = function () use ($config) {
+                        $fields = $config['fields']();
+
+                        return static::addField($fields);
+                    };
+                }
+            }
+            return $config;
+        });
+
+        return $lazyConfig;
+    }
+}

--- a/src/Schema/DynamicSchema/EventSubscriber/PreExecutorSubscriber.php
+++ b/src/Schema/DynamicSchema/EventSubscriber/PreExecutorSubscriber.php
@@ -18,17 +18,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PreExecutorSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var \Overblog\GraphQLBundle\Resolver\FluentResolverInterface
-     */
+    /** @var \Overblog\GraphQLBundle\Resolver\FluentResolverInterface */
     private $typeResolver;
-    /**
-     * @var \Overblog\GraphQLBundle\Definition\ConfigProcessor
-     */
+
+    /** @var \Overblog\GraphQLBundle\Definition\ConfigProcessor */
+
     private $configProcessor;
-    /**
-     * @var \Overblog\GraphQLBundle\Definition\GlobalVariables
-     */
+
+    /** @var \Overblog\GraphQLBundle\Definition\GlobalVariables */
     private $globalVariables;
 
     public function __construct(FluentResolverInterface $typeResolver, ConfigProcessor $configProcessor, GlobalVariables $globalVariables)

--- a/src/Schema/DynamicSchema/EventSubscriber/PreExecutorSubscriber.php
+++ b/src/Schema/DynamicSchema/EventSubscriber/PreExecutorSubscriber.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+
+namespace EzSystems\EzPlatformGraphQL\Schema\DynamicSchema\EventSubscriber;
+
+
+use Overblog\GraphQLBundle\__DEFINITIONS__\HotContentType;
+use Overblog\GraphQLBundle\Definition\ConfigProcessor;
+use Overblog\GraphQLBundle\Definition\GlobalVariables;
+use Overblog\GraphQLBundle\Event\Events;
+use Overblog\GraphQLBundle\Event\ExecutorArgumentsEvent;
+use Overblog\GraphQLBundle\Resolver\FluentResolverInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PreExecutorSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Overblog\GraphQLBundle\Resolver\FluentResolverInterface
+     */
+    private $typeResolver;
+    /**
+     * @var \Overblog\GraphQLBundle\Definition\ConfigProcessor
+     */
+    private $configProcessor;
+    /**
+     * @var \Overblog\GraphQLBundle\Definition\GlobalVariables
+     */
+    private $globalVariables;
+
+    public function __construct(FluentResolverInterface $typeResolver, ConfigProcessor $configProcessor, GlobalVariables $globalVariables)
+    {
+        $this->typeResolver = $typeResolver;
+        $this->configProcessor = $configProcessor;
+        $this->globalVariables = $globalVariables;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [Events::PRE_EXECUTOR => 'updateSchemaFromRepository'];
+    }
+
+    public function updateSchemaFromRepository(ExecutorArgumentsEvent $event)
+    {
+        $this->typeResolver->addSolution(
+            'Overblog\\GraphQLBundle\\__DEFINITIONS__\\HotContentType',
+            [
+                [$this, 'build'],
+                ['Overblog\\GraphQLBundle\\__DEFINITIONS__\\HotContentType']
+            ],
+            ['HotContent'],
+            [
+                'id' => 'Overblog\\GraphQLBundle\\__DEFINITIONS__\\HotContentType',
+                'aliases' => ['HotContent'],
+                'alias' => 'HotContent',
+                'generated' => true
+            ]
+        );
+
+        /**
+         * Could the type class have been written earlier (when the type got modified) ?
+         */
+    }
+
+    public function build($id)
+    {
+        return new HotContentType($this->configProcessor, $this->globalVariables);
+    }
+}

--- a/src/Schema/DynamicSchema/Generator.php
+++ b/src/Schema/DynamicSchema/Generator.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformGraphQL\Schema\DynamicSchema;
+
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+
+class Generator
+{
+    /**
+     * @var Builder
+     */
+    private $schema;
+
+    /**
+     * Grouping of schema types for writing to disk (group => [types]).
+     *
+     * @var array
+     */
+    private $groups;
+
+    /**
+     * @var Domain\Iterator[]
+     */
+    private $iterators;
+
+    /**
+     * @var Worker[]
+     */
+    private $workers;
+
+    public function __construct(Builder $schema, array $iterators, array $workers)
+    {
+        $this->schema = $schema;
+        $this->workers = $workers;
+        $this->iterators = $iterators;
+    }
+
+    /**
+     * @return array
+     */
+    public function generate()
+    {
+        foreach ($this->workers as $worker) {
+            if ($worker instanceof Initializer) {
+                $worker->init($this->schema);
+            }
+        }
+
+        foreach ($this->iterators as $iterator) {
+            $iterator->init($this->schema);
+            foreach ($iterator->iterate() as $arguments) {
+                foreach ($this->workers as $schemaWorker) {
+                    if (!$schemaWorker->canWork($this->schema, $arguments)) {
+                        continue;
+                    }
+                    $schemaWorker->work($this->schema, $arguments);
+                }
+            }
+        }
+
+        return $this->schema->getSchema();
+    }
+}

--- a/src/Schema/DynamicSchema/SchemaDiffBuilder.php
+++ b/src/Schema/DynamicSchema/SchemaDiffBuilder.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\EzPlatformGraphQL\Schema\DynamicSchema;
+
+use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
+use EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder;
+
+/**
+ * A version of the graphql schema builder that doesn't care about non-existent types when adding fields.
+ * It will add the fields as is, and will be able to tell that they're modified fields.
+ */
+class SchemaDiffBuilder extends SchemaBuilder
+{
+    /** @var array */
+    private $modifiedTypes = [];
+
+    /** @var array */
+    private $addedTypes = [];
+
+    public function addFieldToType($type, Input\Field $fieldInput)
+    {
+        if (!$this->hasType($type)) {
+            if (!isset($this->modifiedTypes[$type])) {
+                $this->modifiedTypes[$type] = true;
+            }
+            parent::addType(new Input\Type($type, 'object'));
+        }
+
+        parent::addFieldToType($type, $fieldInput);
+    }
+
+    public function addType(Input\Type $typeInput)
+    {
+        if (!$this->hasType($typeInput->name)) {
+            $this->addedTypes[$typeInput->name] = true;
+        }
+
+        parent::addType($typeInput);
+    }
+
+    public function getModifiedTypes(): array
+    {
+        return $this->filterSchema($this->modifiedTypes);
+    }
+
+    public function getAddedTypes(): array
+    {
+        return $this->filterSchema($this->addedTypes);
+    }
+
+    private function filterSchema(array $types)
+    {
+        return array_filter(
+            $this->getSchema(),
+            function ($type) use ($types) {
+                return isset($types[$type]);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+}


### PR DESCRIPTION
### Background
Right now, when the repository or configuration are modified, the schema must be regenerated by running a command, and the container recompiled. The proof-of-concept belows works around that by hooking into several parts of the schema's building process.

The schema that has been generated on disk is still used to compile the cache, create the services, etc. But after the schema is loaded, it is modified based on changes that happened on the system. Content types can be added or modified.

### Bits and pieces
Most of the code for this is in the `Schema\DynamicSchema` namespace.

#### `HotGraphQLTypesCommand`
One of the temporary entry-points. It simulates what must be done when a change that affects the GraphQL schema occurs, in that case a new content type was added. What it does would be part of some event sub-system attached to the dispatcher.

The script takes a content type identifier as the input, and generates the schema from it as if the console command had been executed. The goal is to:
- create the matching PHP class in `var/cache/{env}/overblog/__DEFINITIONS__/`
- store somewhere that the type was added, as well as the changes to existing types

#### `PreExecutorSubscriber`
Adds hot-loaded types to the types registry (see the command)

#### `DynamicSchema\ConfigProcessor`
Service tagged as `overblog_graphql.type_resolver`. Can process the schema config after it has been read from the configuration and before it gets used.

It shows how a field that loads a content type can be added to the content type group's fields.

#### `SchemaDiffBuilder`
An extended GraphQL schema builder, that:
- accepts additions of fields to unknown types
- logs what types have been added, and what types have been modified

Right now it is used by the script.