### PR TITLE
EZP-31240: Querying for contentobjects missing ImageAsset FieldType in GraphQL ends up with an error

### DIFF
--- a/src/GraphQL/Resolver/ImageAssetFieldResolver.php
+++ b/src/GraphQL/Resolver/ImageAssetFieldResolver.php
@@ -38,8 +38,14 @@ class ImageAssetFieldResolver
 
     public function resolveDomainImageAssetFieldValue(Field $field)
     {
+        $destinationContentId = $field->value->destinationContentId;
+
+        if ($destinationContentId === null) {
+            return null;
+        }
+
         $assetField = $this->assetMapper->getAssetField(
-            $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId))
+            $this->contentLoader->findSingle(new Criterion\ContentId($destinationContentId))
         );
 
         if (empty($assetField->value->alternativeText)) {


### PR DESCRIPTION
JIRA ticket: [EZP-31240](https://jira.ez.no/browse/EZP-31240)

>Currently, when CT definition is modified by adding ImageAsset FieldType and regenerating GraphQL schema, querying by objects which were created before the update ends up with an error.