### PR TITLE
EZP-30517: Dropped RichText Field Type from Kernel code

### DIFF
--- a/src/GraphQL/Mutation/InputHandler/FieldType/RichText.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/RichText.php
@@ -6,11 +6,11 @@
  */
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType;
 
-use eZ\Publish\Core\FieldType\RichText as RichTextFieldType;
 use eZ\Publish\SPI\FieldType\Value;
 use EzSystems\EzPlatformGraphQL\Exception\UnsupportedFieldInputFormatException;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText\RichTextInputConverter;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;
+use EzSystems\EzPlatformRichText\eZ\RichText as RichTextFieldType;
 
 class RichText implements FieldTypeInputHandler
 {
@@ -28,7 +28,7 @@ class RichText implements FieldTypeInputHandler
      * @param array $input
      * @param null $inputFormat
      *
-     * @return RichTextFieldType\Value
+     * @return \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value
      */
     public function toFieldValue($input, $inputFormat = null): Value
     {

--- a/src/GraphQL/Mutation/InputHandler/FieldType/RichText.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/RichText.php
@@ -10,7 +10,7 @@ use eZ\Publish\SPI\FieldType\Value;
 use EzSystems\EzPlatformGraphQL\Exception\UnsupportedFieldInputFormatException;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText\RichTextInputConverter;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;
-use EzSystems\EzPlatformRichText\eZ\RichText as RichTextFieldType;
+use EzSystems\EzPlatformRichText\eZ\FieldType\RichText as RichTextFieldType;
 
 class RichText implements FieldTypeInputHandler
 {

--- a/src/GraphQL/Mutation/InputHandler/FieldType/RichText/HtmlRichTextConverter.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/RichText/HtmlRichTextConverter.php
@@ -7,7 +7,7 @@
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText;
 
 use DOMDocument;
-use eZ\Publish\Core\FieldType\RichText as RichTextFieldType;
+use EzSystems\EzPlatformRichText\eZ\RichText as RichTextFieldType;
 
 class HtmlRichTextConverter implements RichTextInputConverter
 {

--- a/src/GraphQL/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
+++ b/src/GraphQL/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
@@ -7,7 +7,7 @@
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldType\RichText;
 
 use DOMDocument;
-use eZ\Publish\Core\FieldType\RichText as RichTextFieldType;
+use EzSystems\EzPlatformRichText\eZ\RichText as RichTextFieldType;
 use Parsedown;
 
 class MarkdownRichTextConverter implements RichTextInputConverter

--- a/src/GraphQL/Resolver/RichTextResolver.php
+++ b/src/GraphQL/Resolver/RichTextResolver.php
@@ -7,7 +7,7 @@
 namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 
 use DOMDocument;
-use eZ\Publish\Core\FieldType\RichText\Converter as RichTextConverterInterface;
+use EzSystems\EzPlatformRichText\eZ\RichText\Converter as RichTextConverterInterface;
 
 /**
  * @internal


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30517

### Description 

RichText Field Type was dropped from the Kernel code in https://github.com/ezsystems/ezpublish-kernel/pull/2659 so all `eZ\Publish\Core\FieldType\RichText\**`  imports should be updated to `EzSystems\EzPlatformRichText\eZ\RichText\**`. Otherwise, any usage of mutations will cause: 

```
Argument 1 passed to EzSystems\\EzPlatformGraphQL\\GraphQL\\Mutation\\InputHandler\\FieldType\\RichText\\HtmlRichTextConverter::__construct() must be an instance of eZ\\Publish\\Core\\FieldType\\RichText\\Converter, instance of Aggregate_f3ff3dd given, called in /Users/awojs/eZ/ezplatform-ee-3.0-beta4/var/cache/dev/ContainerQaxwiHC/getDomainContentMutationResolverService.php on line 27
```

