### PR TITLE
 EZP-31078: Enhanced Content Type Value Object

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
 
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
 use spec\EzSystems\EzPlatformGraphQL\Tools\TypeArgument;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
@@ -83,11 +84,11 @@ class ContentDomainIteratorSpec extends ObjectBehavior
         $contentTypeService->loadContentTypes(Argument::any())->willReturn([
             $type = new ContentType([
                 'identifier' => 'type',
-                'fieldDefinitions' => [
+                'fieldDefinitions' => new FieldDefinitionCollection([
                     'field1' => $field1 = new FieldDefinition(),
                     'field2' => $field2 = new FieldDefinition(),
                     'field3' => $field3 = new FieldDefinition(),
-                ]
+                ])
             ]),
         ]);
 
@@ -111,15 +112,15 @@ class ContentDomainIteratorSpec extends ObjectBehavior
         $contentTypeService->loadContentTypes(Argument::any())->willReturn([
             $type1 = new ContentType([
                 'identifier' => 'type1',
-                'fieldDefinitions' => [
+                'fieldDefinitions' => new FieldDefinitionCollection([
                     'type1_field1' => ($type1field1 = new FieldDefinition()),
-                ]
+                ])
             ]),
             $type2 = new ContentType([
                 'identifier' => 'type2',
-                'fieldDefinitions' => [
+                'fieldDefinitions' => new FieldDefinitionCollection([
                     'type2_field1' => ($type2field1 = new FieldDefinition()),
-                ]
+                ])
             ]),
         ]);
 

--- a/src/GraphQL/Resolver/DomainContentMutationResolver.php
+++ b/src/GraphQL/Resolver/DomainContentMutationResolver.php
@@ -9,6 +9,7 @@ namespace EzSystems\EzPlatformGraphQL\GraphQL\Resolver;
 use eZ\Publish\API\Repository as API;
 use eZ\Publish\API\Repository\Exceptions as RepositoryExceptions;
 use eZ\Publish\API\Repository\Values as RepositoryValues;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\EzPlatformGraphQL\Exception\UnsupportedFieldTypeException;
 use EzSystems\EzPlatformGraphQL\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
@@ -207,7 +208,7 @@ class DomainContentMutationResolver
         ];
     }
 
-    private function getInputFieldValue($fieldInput, RepositoryValues\ContentType\FieldDefinition $fieldDefinition)
+    private function getInputFieldValue($fieldInput, FieldDefinition $fieldDefinition)
     {
         if (isset($this->fieldInputHandlers[$fieldDefinition->fieldTypeIdentifier])) {
             $format = null;
@@ -270,7 +271,12 @@ class DomainContentMutationResolver
     {
         $errors = [];
         foreach ($e->getFieldErrors() as $fieldDefId => $fieldErrors) {
-            $fieldDefinition = $contentType->getFieldDefinitionById($fieldDefId);
+            $fieldDefinition = $contentType->getFieldDefinitions()->filter(
+                static function (FieldDefinition $fieldDefinition) use ($fieldDefId) {
+                    return $fieldDefinition->id === $fieldDefId;
+                }
+            )->first();
+
             foreach ($fieldErrors['eng-GB'] as $fieldError) {
                 $translatableMessage = $fieldError->getTranslatableMessage();
                 if ($translatableMessage instanceof API\Values\Translation\Plural) {
@@ -300,7 +306,7 @@ class DomainContentMutationResolver
      *
      * @return string
      */
-    private function getInputField(API\Values\ContentType\FieldDefinition $fieldDefinition)
+    private function getInputField(FieldDefinition $fieldDefinition)
     {
         return $this->nameHelper->fieldDefinitionField($fieldDefinition);
     }


### PR DESCRIPTION
> JIRA: [EZP-31078](https://jira.ez.no/browse/EZP-31078)

## Description 

Follow up for https://github.com/ezsystems/ezpublish-kernel/pull/2839. PR contains two related changes: 
* https://github.com/ezsystems/ezplatform-graphql/commit/947a6df1eedaae6ae108d2bf180c93aa8428d9c1 adjust PHP spec to unblock CI
* https://github.com/ezsystems/ezplatform-graphql/commit/cec4aea874c0b63e0fa0be487ddc8393e02e709d replaces `eZ\Publish\Core\Repository\Values\ContentType\ContentType::getFieldDefinitionById` method usages  