### PR TITLE
EZP-31597: Handled missing Content Types when generating Schema

### DIFF
--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
@@ -9,6 +9,7 @@ namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefiniti
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
+use eZ\Publish\Core\Persistence\Legacy\Exception\TypeNotFound;
 
 class RelationFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
 {
@@ -39,11 +40,12 @@ class RelationFieldDefinitionMapper extends DecoratingFieldDefinitionMapper impl
         }
         $settings = $fieldDefinition->getFieldSettings();
 
+        $type = 'DomainContent';
         if (count($settings['selectionContentTypes']) === 1) {
-            $contentType = $this->contentTypeService->loadContentTypeByIdentifier($settings['selectionContentTypes'][0]);
-            $type = $this->nameHelper->domainContentName($contentType);
-        } else {
-            $type = 'DomainContent';
+            try {
+                $contentType = $this->contentTypeService->loadContentTypeByIdentifier($settings['selectionContentTypes'][0]);
+                $type = $this->nameHelper->domainContentName($contentType);
+            } catch (TypeNotFound $e) {}
         }
 
         if ($this->isMultiple($fieldDefinition)) {

--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
@@ -7,9 +7,9 @@
 namespace EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper;
-use eZ\Publish\Core\Persistence\Legacy\Exception\TypeNotFound;
 
 class RelationFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
 {
@@ -43,9 +43,13 @@ class RelationFieldDefinitionMapper extends DecoratingFieldDefinitionMapper impl
         $type = 'DomainContent';
         if (count($settings['selectionContentTypes']) === 1) {
             try {
-                $contentType = $this->contentTypeService->loadContentTypeByIdentifier($settings['selectionContentTypes'][0]);
+                $contentType = $this->contentTypeService->loadContentTypeByIdentifier(
+                    $settings['selectionContentTypes'][0]
+                );
                 $type = $this->nameHelper->domainContentName($contentType);
-            } catch (TypeNotFound $e) {}
+            } catch (NotFoundException $e) {
+                // Nothing to do
+            }
         }
 
         if ($this->isMultiple($fieldDefinition)) {


### PR DESCRIPTION
More details at https://jira.ez.no/browse/EZP-31597

Also, it might worth showing errors like this during the schema update, but it would require injecting the logger into the mappers.

@bdunogier 