### PR TITLE
Fixing image variations resolver

### DIFF
--- a/src/Resources/config/graphql/Field.types.yml
+++ b/src/Resources/config/graphql/Field.types.yml
@@ -42,7 +42,7 @@ ImageFieldValue:
                     identifier:
                         type: "[ImageVariationIdentifier]!"
                         description: "One or more variation identifiers."
-                resolve: "@=resolver('ImageVariation', [value.value, args])"
+                resolve: "@=resolver('ImageVariations', [value.value, args])"
             variation:
                 type: ImageVariation
                 args:


### PR DESCRIPTION
I had issues fetching multiple image variations in a single request 
(Array to String Conversion)

Upon debugging i figured the field type resolver is wrong