### PR TITLE
Deprecated the 'id' content argument in favour of 'contentId'

### DIFF
--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -82,7 +82,10 @@ class DomainContentResolver
      */
     public function resolveDomainContentItem($args, $contentTypeIdentifier)
     {
-        if (isset($args['id'])) {
+        if (isset($args['contentId'])) {
+            $criterion = new Query\Criterion\ContentId($args['id']);
+        } elseif (isset($args['id'])) {
+            @trigger_error("The 'id' argument is deprecated since v2.3.0, use 'contentId' instead", E_USER_DEPRECATED);
             $criterion = new Query\Criterion\ContentId($args['id']);
         } elseif (isset($args['remoteId'])) {
             $criterion = new Query\Criterion\RemoteId($args['remoteId']);

--- a/src/Resources/config/graphql/Location.types.yaml
+++ b/src/Resources/config/graphql/Location.types.yaml
@@ -54,7 +54,7 @@ Location:
                 resolve: "@=value.getContentInfo()"
             content:
                 type: DomainContent
-                resolve: "@=resolver('DomainContentItem', [{id: value.contentId}, null])"
+                resolve: "@=resolver('DomainContentItem', [{contentId: value.contentId}, null])"
 
 LocationSortByOptions:
     type: enum

--- a/src/Schema/Builder/Input/Arg.php
+++ b/src/Schema/Builder/Input/Arg.php
@@ -19,4 +19,5 @@ class Arg extends Input
     public $type;
     public $description;
     public $defaultValue;
+    public $deprecationReason;
 }

--- a/src/Schema/Builder/SchemaBuilder.php
+++ b/src/Schema/Builder/SchemaBuilder.php
@@ -88,6 +88,10 @@ class SchemaBuilder implements SchemaBuilderInterface
             $arg['defaultValue'] = $argInput->defaultValue;
         }
 
+        if (!empty($argInput->deprecationReason)) {
+            $arg['deprecationReason'] = $argInput->deprecationReason;
+        }
+
         $this->schema[$type]['config']['fields'][$field]['args'][$argInput->name] = $arg;
     }
 

--- a/src/Schema/Domain/Content/Worker/ContentType/AddDomainContentToDomainGroup.php
+++ b/src/Schema/Domain/Content/Worker/ContentType/AddDomainContentToDomainGroup.php
@@ -30,6 +30,11 @@ class AddDomainContentToDomainGroup extends BaseWorker implements Worker
 
         $schema->addArgToField($this->groupName($args), $this->typeField($args), new Input\Arg(
             'id', 'Int',
+            ['description' => sprintf('Content ID of the %s (deprecated since v2.3.0 of ezplatform-graphql, use contentId instead)', $contentType->identifier)]
+        ));
+
+        $schema->addArgToField($this->groupName($args), $this->typeField($args), new Input\Arg(
+            'contentId', 'Int',
             ['description' => sprintf('Content ID of the %s', $contentType->identifier)]
         ));
 


### PR DESCRIPTION
The title says it all.