### PR TITLE
Upgraded overblog/graphql-bundle to v0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ezsystems/ezplatform-rest": "^1.2@dev",
         "ezsystems/ezplatform-richtext": "^2.0@dev",
         "lexik/jwt-authentication-bundle": "^2.8",
-        "overblog/graphql-bundle": "^0.11",
+        "overblog/graphql-bundle": "^0.12",
         "erusev/parsedown": "^1.7",
         "symfony/dependency-injection": "^5.0",
         "symfony/http-kernel": "^5.0",


### PR DESCRIPTION
Required to fix ordering issues of extensions that prepend graphql types. In v0.12 of overblog/graphqlbundle, the types definitions aren't handled with a container extension anymore, but with a compiler pass.

### TODO
- [ ] merge to 3.0