### PR TITLE
EZP-32303: As a Developer I want GraphQL allow filtering by Subtree and IsFieldEmpty

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/GraphQL/InputMapper/SearchQueryMapperSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/GraphQL/InputMapper/SearchQueryMapperSpec.php
@@ -25,6 +25,20 @@ class SearchQueryMapperSpec extends ObjectBehavior
             ->shouldFilterByFullText('graphql');
     }
 
+    public function it_maps_Subtree_to_a_Subtree_criterion()
+    {
+        $this
+            ->mapInputToQuery(['Subtree' => '/1/2/'])
+            ->shouldFilterBySubtree(['/1/2/']);
+    }
+
+    public function it_maps_IsFieldEmpty_to_a_IsFieldEmpty_criterion()
+    {
+        $this
+            ->mapInputToQuery(['IsFieldEmpty' => ['target' => 'title', 'empty' => false]])
+            ->shouldFilterByIsFieldEmpty('title', false);
+    }
+
     public function it_maps_Modified_before_to_a_created_lte_DateMetaData_criterion()
     {
         $this
@@ -207,6 +221,30 @@ class SearchQueryMapperSpec extends ObjectBehavior
                     return false;
                 }
                 return ($value === null || $criterion->value == $value);
+            },
+            'filterBySubtree' => function (Query $query, array $subtree) {
+                $criterion = $this->findCriterionInQueryFilter(
+                    $query,
+                    Query\Criterion\Subtree::class
+                );
+
+                if ($criterion === null) {
+                    return false;
+                }
+
+                return $criterion->value === $subtree;
+            },
+            'filterByIsFieldEmpty' => function (Query $query, string $field, bool $empty) {
+                $criterion = $this->findCriterionInQueryFilter(
+                    $query,
+                    Query\Criterion\IsFieldEmpty::class
+                );
+
+                if ($criterion === null) {
+                    return false;
+                }
+
+                return $criterion->target === $field && $criterion->value[0] === $empty;
             },
             'filterByFieldWithOperator' => function(Query $query, $operator) {
                 $criterion = $this->findCriterionInQueryFilter($query, Query\Criterion\Field::class);

--- a/src/GraphQL/InputMapper/SearchQueryMapper.php
+++ b/src/GraphQL/InputMapper/SearchQueryMapper.php
@@ -52,6 +52,15 @@ class SearchQueryMapper
         if (isset($inputArray['ParentLocationId'])) {
             $criteria[] = new Query\Criterion\ParentLocationId($inputArray['ParentLocationId']);
         }
+        if (isset($inputArray['Subtree'])) {
+            $criteria[] = new Query\Criterion\Subtree($inputArray['Subtree']);
+        }
+        if (isset($inputArray['IsFieldEmpty'])) {
+            $criteria[] = new Query\Criterion\IsFieldEmpty(
+                $inputArray['IsFieldEmpty']['target'],
+                $inputArray['IsFieldEmpty']['empty']
+            );
+        }
 
         $criteria = array_merge($criteria, $this->mapDateMetadata($inputArray, 'Modified'));
         $criteria = array_merge($criteria, $this->mapDateMetadata($inputArray, 'Created'));

--- a/src/Resources/config/graphql/Search.types.yaml
+++ b/src/Resources/config/graphql/Search.types.yaml
@@ -20,11 +20,29 @@ ContentSearchQuery:
             ParentLocationId:
                 type: "[Int]"
                 description: "Filter content based on its parent location id"
+            Subtree:
+                type: "[String]"
+                description: "Filter content based on its subtree location"
+            IsFieldEmpty:
+                type: "IsFieldEmptyInput"
+                description: "Filter content based on field is empty or not"
             Field:
                 type: "[FieldCriterionInput]"
                 description: "Field filter"
             SortBy:
                 type: "SortByOptions"
+
+IsFieldEmptyInput:
+    type: "input-object"
+    config:
+        fields:
+            target:
+                type: "String"
+                description: "A field definition identifier"
+            empty:
+                type: "Boolean"
+                description: "If field is empty or not"
+                defaultValue: true
 
 FieldCriterionInput:
      type: "input-object"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-32303](https://issues.ibexa.co/browse/EZP-32303)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Currently, it's not possible to filter content by Subtree (while parent location id available).
I would like to add more filters, like Subtree and IsFieldEmpty.
```
{
  content {
    folders(query: {
      Subtree: "/1/2/63"
      IsFieldEmpty: {
        target: "description"
        empty: false
      }
    }) {
      edges {
        node { name }
      }
    }
  }
}
```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
