### PR TITLE
EZP-32379: Deleted unusable thumbnail generation based on 'ezobjectrelation'

### DIFF
--- a/src/GraphQL/Resolver/ContentThumbnailResolver.php
+++ b/src/GraphQL/Resolver/ContentThumbnailResolver.php
@@ -85,18 +85,6 @@ final class ContentThumbnailResolver
                 $assetContent = $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId));
 
                 return $this->assetMapper->getAssetField($assetContent);
-            } elseif ($field->fieldTypeIdentifier === 'ezobjectrelation') {
-                $relatedContent = $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId));
-
-                return $this->getThumbnailImageField($relatedContent);
-            }
-        }
-
-        foreach ($content->getFieldsByLanguage() as $field) {
-            if ($field->fieldTypeIdentifier === 'ezobjectrelation') {
-                $relatedContent = $this->contentLoader->findSingle(new Criterion\ContentId($field->value->destinationContentId));
-
-                return $this->getThumbnailImageField($relatedContent);
             }
         }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-32379](https://issues.ibexa.co/browse/EZP-32379)
| **Type**                                   | bug
| **Target eZ Platform version** | v3.2
| **BC breaks**                          | no
| **Doc needed**                       | no

As for now, thumbnails are not generated based on 'ezobjectrelation' field type. There is no such strategy (unlike for 'Image' or 'ImageAsset' - `ezplatform-kernel/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/FieldTypeBasedThumbnailStrategy`), therefore the "is Thumbnail" field is disabled in case of 'ezobjectrelation'.

This PR fixes the infinite loop originating from the circular relation between two Content Types as well.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
