### PR TITLE
variations → variation; alias → identifier; html → html5 

### DIFF
--- a/doc/domain_schema.md
+++ b/doc/domain_schema.md
@@ -30,7 +30,7 @@ Queries look like this:
       body { html }
       image {
         name
-        variations(alias: large) { uri }
+        variation(identifier: large) { uri }
       }
     }
     folder(id: 1234) {

--- a/doc/domain_schema.md
+++ b/doc/domain_schema.md
@@ -27,7 +27,7 @@ Queries look like this:
   content {
     articles {
       title
-      body { html }
+      body { html5 }
       image {
         name
         variation(identifier: large) { uri }


### PR DESCRIPTION
- For only one variation, using `variation` instead of `variations` could be better.
- `variation` and `variations` both use `identifier` argument, not `alias`.
- RichText has `html5` instead of `html`