### PR TITLE
IBX-1130: Add language argument to translatable fields

### DIFF
--- a/src/GraphQL/Resolver/DomainContentResolver.php
+++ b/src/GraphQL/Resolver/DomainContentResolver.php
@@ -131,9 +131,9 @@ class DomainContentResolver
         return isset($aliases[0]->path) ? $aliases[0]->path : null;
     }
 
-    public function resolveDomainFieldValue(Content $content, $fieldDefinitionIdentifier)
+    public function resolveDomainFieldValue(Content $content, $fieldDefinitionIdentifier, $args = null)
     {
-        return Field::fromField($content->getField($fieldDefinitionIdentifier));
+        return Field::fromField($content->getField($fieldDefinitionIdentifier, $args['language'] ?? null));
     }
 
     public function resolveDomainRelationFieldValue(Field $field, $multiple = false)

--- a/src/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
+++ b/src/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
@@ -45,7 +45,7 @@ class ResolverVariables implements FieldDefinitionMapper
             ],
             [
                 'value',
-                'resolver("DomainFieldValue", [value, "' . $fieldDefinition->identifier . '"])',
+                'resolver("DomainFieldValue", [value, "' . $fieldDefinition->identifier . '", args])',
             ],
             $resolver
         );

--- a/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
+++ b/src/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToDomainContent.php
@@ -33,6 +33,14 @@ class AddFieldValueToDomainContent extends BaseWorker implements Worker
             $this->typeName($args),
             new Input\Field($this->fieldName($args), $definition['type'], $definition)
         );
+
+        if ($args['FieldDefinition']->isTranslatable) {
+            $schema->addArgToField(
+                $this->typeName($args),
+                $this->fieldName($args),
+                new Input\Arg('language', 'RepositoryLanguage')
+            );
+        }
     }
 
     private function getDefinition(FieldDefinition $fieldDefinition)


### PR DESCRIPTION
| Question                                  | Answer
| ----------------------------------------- | ------------------
| **JIRA issue**                            | https://issues.ibexa.co/browse/IBX-1130
| **Type**                                  | feature
| **Target Ibexa DXP version**              | `v3.3.10` 
| **BC breaks**                             | no 

New version of #56 for the 2.3 branch.

Gives more flexibility when querying multilingual content. As long as the current siteaccess is configured with several (or all) languages, multiple translations of each field can be obtained at once.

When no language is specified, the previous behaviour is maintained, and the most prioritized existing translation is used.

![image](https://user-images.githubusercontent.com/235928/136574101-a3db149e-07dd-4416-886f-f9aa3c7e2114.png)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage (kinda)
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`). 
- [x] Asked for a review (ping `@ibexa/engineering`).


