### PR TITLE
Removed duplicated ContentDomainIterator service definition

### DIFF
--- a/src/Resources/config/services/schema.yml
+++ b/src/Resources/config/services/schema.yml
@@ -77,8 +77,6 @@ services:
 
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Worker\Language\AddLanguageToEnum: ~
 
-    EzSystems\EzPlatformGraphQL\Schema\Domain\Content\ContentDomainIterator: ~
-
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\LanguagesIterator: ~
 
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper: ~


### PR DESCRIPTION

Removed duplicated `EzSystems\EzPlatformGraphQL\Schema\Domain\Content\ContentDomainIterator` service definition.

Second (and correct) occurrence is in https://github.com/ezsystems/ezplatform-graphql/blob/1.0/src/Resources/config/services/schema.yml#L94-L98