### PR TITLE
IBX-1520: Fixed loading sub-items on PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ezsystems/ezplatform-rest": "^1.2@dev",
         "ezsystems/ezplatform-richtext": "^2.0@dev",
         "lexik/jwt-authentication-bundle": "^2.8",
-        "overblog/graphql-bundle": "^0.12",
+        "overblog/graphql-bundle": "^0.13",
         "erusev/parsedown": "^1.7",
         "symfony/dependency-injection": "^5.0",
         "symfony/http-kernel": "^5.0",


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-1520

>While loading sub-items, we end up with an error:
>`preg_replace_callback(): Argument #3 ($subject) must be of type array|string, null given`
>
>This was fixed within `overblog/graphql-bundle 0.13.6`, ref: >https://github.com/overblog/GraphQLBundle/commit/f66613b2f283691af04f77d0b66ff20b5867fef4. Therefore the package needs to be updated.
