### PR TITLE
doc: Actually store the modified schema parameter in compiler pass

### DIFF
--- a/doc/howto/custom_field_type.md
+++ b/doc/howto/custom_field_type.md
@@ -58,6 +58,7 @@ class LandingPageGraphQLConfigurationPass implements CompilerPassInterface
             'definition_type' => 'MyCustomFieldDefinition',
             'value_resolver' => 'field.someProperty'
         ];
+        $container->setParameter('ezplatform_graphql.schema.content.mapping.field_definition_type', $mapping);
     }
 }
 ```


### PR DESCRIPTION
The doc for showing how to map a custom field type into the graphql schema has a minor bug.

This is a new PR based on https://github.com/ezsystems/ezplatform-graphql/pull/67 ( which was based on wrong branch and was closed )