### PR TITLE
IBX-1565: Refactor schema's types' names validation

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Builder/SchemaBuilderSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Builder/SchemaBuilderSpec.php
@@ -1,10 +1,16 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace spec\EzSystems\EzPlatformGraphQL\Schema\Builder;
 
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder;
+use Ibexa\GraphQL\Schema\Domain\NameValidator;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class SchemaBuilderSpec extends ObjectBehavior
 {
@@ -17,13 +23,20 @@ class SchemaBuilderSpec extends ObjectBehavior
     const ARG = 'arg';
     const ARG_TYPE = 'Boolean';
 
-    function it_is_initializable()
+    public function let(NameValidator $nameValidator)
+    {
+        $this->beConstructedWith($nameValidator);
+    }
+
+    public function it_is_initializable()
     {
         $this->shouldHaveType(SchemaBuilder::class);
     }
 
-    function it_adds_a_type_to_the_schema()
+    public function it_adds_a_type_to_the_schema(NameValidator $nameValidator)
     {
+        $nameValidator->isValidName(Argument::any())->willReturn(true);
+
         $this->addType($this->inputType('Parent', 'Interface'));
 
         $schema = $this->getSchema();
@@ -33,8 +46,10 @@ class SchemaBuilderSpec extends ObjectBehavior
         $schema->shouldHaveGraphQLTypeThatImplements('Interface');
     }
 
-    function it_adds_a_field_to_an_existing_type()
+    public function it_adds_a_field_to_an_existing_type(NameValidator $nameValidator)
     {
+        $nameValidator->isValidName(Argument::any())->willReturn(true);
+
         $this->addType($this->inputType());
         $this->addFieldToType(self::TYPE,
             $this->inputField('Description', '@=resolver("myresolver")')
@@ -47,8 +62,10 @@ class SchemaBuilderSpec extends ObjectBehavior
         $schema->shouldHaveGraphQLTypeFieldWithResolve('@=resolver("myresolver")');
     }
 
-    function it_adds_an_argument_to_an_existing_type_field()
+    public function it_adds_an_argument_to_an_existing_type_field(NameValidator $nameValidator)
     {
+        $nameValidator->isValidName(Argument::any())->willReturn(true);
+
         $this->addType($this->inputType());
         $this->addFieldToType(self::TYPE, $this->inputField());
         $this->addArgToField(self::TYPE, self::FIELD, $this->inputArg('Description'));
@@ -112,7 +129,7 @@ class SchemaBuilderSpec extends ObjectBehavior
             self::TYPE, self::TYPE_TYPE,
             [
                 'inherits' => $inherits,
-                'interfaces' => $interfaces
+                'interfaces' => $interfaces,
             ]
         );
     }

--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
@@ -54,7 +54,7 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     }
 
     function it_yields_content_types_with_their_group_from_a_content_type_group(
-        ContentTypeService $contentTypeService,
+        ContentTypeService $contentTypeService
     ) {
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group = new ContentTypeGroup(['identifier' => 'Group']),

--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
@@ -1,7 +1,6 @@
 <?php
 namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
 
-use Ibexa\GraphQL\Schema\Domain\NameValidator;
 use spec\EzSystems\EzPlatformGraphQL\Tools\TypeArgument;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
@@ -14,11 +13,9 @@ use EzSystems\EzPlatformGraphQL\Schema\Builder;
 
 class ContentDomainIteratorSpec extends ObjectBehavior
 {
-    public function let(
-        ContentTypeService $contentTypeService,
-        NameValidator $nameValidator
-    ) {
-        $this->beConstructedWith($contentTypeService, $nameValidator);
+    public function let(ContentTypeService $contentTypeService)
+    {
+        $this->beConstructedWith($contentTypeService);
     }
 
     function it_is_initializable()
@@ -38,10 +35,8 @@ class ContentDomainIteratorSpec extends ObjectBehavior
         )->shouldHaveBeenCalled();
     }
 
-    function it_yields_content_type_groups(ContentTypeService $contentTypeService, NameValidator $nameValidator)
+    function it_yields_content_type_groups(ContentTypeService $contentTypeService)
     {
-        $nameValidator->isValidName(Argument::any())->willReturn(true);
-
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group1 = new ContentTypeGroup(['identifier' => 'Group 1']),
             $group2 = new ContentTypeGroup(['identifier' => 'Group 2']),
@@ -60,10 +55,7 @@ class ContentDomainIteratorSpec extends ObjectBehavior
 
     function it_yields_content_types_with_their_group_from_a_content_type_group(
         ContentTypeService $contentTypeService,
-        NameValidator $nameValidator
     ) {
-        $nameValidator->isValidName(Argument::any())->willReturn(true);
-
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group = new ContentTypeGroup(['identifier' => 'Group']),
         ]);
@@ -84,11 +76,8 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     }
 
     function it_yields_fields_definitions_with_their_content_types_and_group_from_a_content_type(
-        ContentTypeService $contentTypeService,
-        NameValidator $nameValidator
+        ContentTypeService $contentTypeService
     ) {
-        $nameValidator->isValidName(Argument::any())->willReturn(true);
-
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group = new ContentTypeGroup(['identifier' => 'Group']),
         ]);
@@ -115,11 +104,8 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     }
 
     function it_only_yields_fields_definitions_from_the_current_content_type(
-        ContentTypeService $contentTypeService,
-        NameValidator $nameValidator
+        ContentTypeService $contentTypeService
     ) {
-        $nameValidator->isValidName(Argument::any())->willReturn(true);
-
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group = new ContentTypeGroup([
                 'identifier' => 'group'

--- a/src/Resources/config/services/schema.yml
+++ b/src/Resources/config/services/schema.yml
@@ -17,7 +17,13 @@ services:
             tags:
                 - {name: 'ezplatform_graphql.schema_domain_iterator'}
 
-    EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder: ~
+    EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder:
+        arguments:
+            - '@Ibexa\GraphQL\Schema\Domain\NameValidator'
+        calls:
+            - method: setLogger
+              arguments:
+                  - '@logger'
 
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper:
         alias: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\DefaultFieldDefinitionMapper
@@ -83,17 +89,9 @@ services:
 
     Ibexa\GraphQL\Schema\Domain\NameValidator: ~
 
-    EzSystems\EzPlatformGraphQL\Schema\Domain\ImageVariationDomain:
-        calls:
-            - method: setLogger
-              arguments:
-                  - '@logger'
+    EzSystems\EzPlatformGraphQL\Schema\Domain\ImageVariationDomain: ~
 
-    EzSystems\EzPlatformGraphQL\Schema\Domain\Content\ContentDomainIterator:
-        calls:
-            - method: setLogger
-              arguments:
-                  - '@logger'
+    EzSystems\EzPlatformGraphQL\Schema\Domain\Content\ContentDomainIterator: ~
 
     EzSystems\EzPlatformGraphQL\Schema\Builder:
         alias: 'EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder'

--- a/src/Schema/Builder/SchemaBuilder.php
+++ b/src/Schema/Builder/SchemaBuilder.php
@@ -180,10 +180,9 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
 
     private function generateInvalidGraphQLNameWarning(string $type, string $name): void
     {
-        $message = "Skipping schema generation for %s with identifier '%s'. "
-            . 'Please rename given %s according to GraphQL specification '
-            . '(http://spec.graphql.org/June2018/#sec-Names)';
+        $message = "Skipping schema generation for %s with identifier '%s' as it stands against GraphQL specification. "
+            . 'For more details see http://spec.graphql.org/[latest-release]/#sec-Names.';
 
-        $this->logger->warning(sprintf($message, $type, $name, $type));
+        $this->logger->warning(sprintf($message, $type, $name));
     }
 }

--- a/src/Schema/Builder/SchemaBuilder.php
+++ b/src/Schema/Builder/SchemaBuilder.php
@@ -36,6 +36,7 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
     {
         if (!$this->nameValidator->isValidName($typeInput->name)) {
             $this->generateInvalidGraphQLNameWarning($typeInput->type, $typeInput->name);
+
             return;
         }
 
@@ -65,6 +66,7 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
     {
         if (!$this->nameValidator->isValidName($fieldInput->name)) {
             $this->generateInvalidGraphQLNameWarning($fieldInput->type, $fieldInput->name);
+
             return;
         }
 

--- a/src/Schema/Domain/Content/ContentDomainIterator.php
+++ b/src/Schema/Domain/Content/ContentDomainIterator.php
@@ -11,26 +11,15 @@ use EzSystems\EzPlatformGraphQL\Schema\Builder;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Iterator;
 use Generator;
-use Ibexa\GraphQL\Schema\Domain\NameValidator;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
-use Psr\Log\NullLogger;
 
-class ContentDomainIterator implements Iterator, LoggerAwareInterface
+class ContentDomainIterator implements Iterator
 {
-    use LoggerAwareTrait;
-
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
 
-    /** @var \Ibexa\GraphQL\Schema\Domain\NameValidator */
-    private $nameValidator;
-
-    public function __construct(ContentTypeService $contentTypeService, NameValidator $nameValidator)
+    public function __construct(ContentTypeService $contentTypeService)
     {
         $this->contentTypeService = $contentTypeService;
-        $this->nameValidator = $nameValidator;
-        $this->logger = new NullLogger();
     }
 
     public function init(Builder $schema)
@@ -43,42 +32,18 @@ class ContentDomainIterator implements Iterator, LoggerAwareInterface
     public function iterate(): Generator
     {
         foreach ($this->contentTypeService->loadContentTypeGroups() as $contentTypeGroup) {
-            if (!$this->nameValidator->isValidName($contentTypeGroup->identifier)) {
-                $this->generateInvalidGraphQLNameWarning('Content Type Group', $contentTypeGroup->identifier);
-                continue;
-            }
-
             yield ['ContentTypeGroup' => $contentTypeGroup];
 
             foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
-                if (!$this->nameValidator->isValidName($contentType->identifier)) {
-                    $this->generateInvalidGraphQLNameWarning('Content Type', $contentType->identifier);
-                    continue;
-                }
-
                 yield ['ContentTypeGroup' => $contentTypeGroup]
                     + ['ContentType' => $contentType];
 
                 foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
-                    if (!$this->nameValidator->isValidName($fieldDefinition->identifier)) {
-                        $this->generateInvalidGraphQLNameWarning('Field Definition', $fieldDefinition->identifier);
-                        continue;
-                    }
-
                     yield ['ContentTypeGroup' => $contentTypeGroup]
                         + ['ContentType' => $contentType]
                         + ['FieldDefinition' => $fieldDefinition];
                 }
             }
         }
-    }
-
-    private function generateInvalidGraphQLNameWarning(string $type, string $name): void
-    {
-        $message = "Skipped schema generation for %s with identifier '%s'. "
-            . 'Please rename given %s according to GraphQL specification '
-            . '(http://spec.graphql.org/June2018/#sec-Names)';
-
-        $this->logger->warning(sprintf($message, $type, $name, $type));
     }
 }

--- a/src/Schema/Domain/ImageVariationDomain.php
+++ b/src/Schema/Domain/ImageVariationDomain.php
@@ -23,7 +23,8 @@ class ImageVariationDomain implements Domain\Iterator, Schema\Worker
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
-    public function __construct(ConfigResolverInterface $configResolver) {
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
         $this->configResolver = $configResolver;
     }
 

--- a/src/Schema/Domain/ImageVariationDomain.php
+++ b/src/Schema/Domain/ImageVariationDomain.php
@@ -11,48 +11,25 @@ use EzSystems\EzPlatformGraphQL\Schema;
 use EzSystems\EzPlatformGraphQL\Schema\Builder;
 use EzSystems\EzPlatformGraphQL\Schema\Domain;
 use Generator;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
-use Psr\Log\NullLogger;
-use Ibexa\GraphQL\Schema\Domain\NameValidator;
 
 /**
  * Adds configured image variations to the ImageVariationIdentifier type.
  */
-class ImageVariationDomain implements Domain\Iterator, Schema\Worker, LoggerAwareInterface
+class ImageVariationDomain implements Domain\Iterator, Schema\Worker
 {
-    use LoggerAwareTrait;
-
     const TYPE = 'ImageVariationIdentifier';
     const ARG = 'ImageVariation';
 
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
-    /** @var \Ibexa\GraphQL\Schema\Domain\NameValidator */
-    private $nameValidator;
-
-    public function __construct(
-        ConfigResolverInterface $configResolver,
-        NameValidator $nameValidator
-    ) {
+    public function __construct(ConfigResolverInterface $configResolver) {
         $this->configResolver = $configResolver;
-        $this->nameValidator = $nameValidator;
-        $this->logger = new NullLogger();
     }
 
     public function iterate(): Generator
     {
         foreach ($this->configResolver->getParameter('image_variations') as $identifier => $variation) {
-            if (!$this->nameValidator->isValidName($identifier)) {
-                $message = "Skipped schema generation for Image Variation with identifier '%s'. "
-                    . 'Please rename given image variation according to GraphQL specification '
-                    . '(http://spec.graphql.org/June2018/#sec-Names)';
-
-                $this->logger->warning(sprintf($message, $identifier));
-                continue;
-            }
-
             yield [self::ARG => ['identifier' => $identifier, 'variation' => $variation]];
         }
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1565](https://issues.ibexa.co/browse/IBX-1565)
| **Type**                                   | bug
| **Target version** | `v2.5`
| **BC breaks**                          | no

`Content Type Groups` don't have an identifier that matches the GraphQL standard, they have only names. Therefore the problem arises in every Group which has some special chars and the schema is not generated at all for them, even though the name would be transformed.

The validation should occur after the identifiers have been transformed according to the standard, not before. This solution also simplifies code and avoids repeats.