### PR TITLE
IBX-2155: Handled invalid enum values

### DIFF
--- a/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
+++ b/spec/EzSystems/EzPlatformGraphQL/Schema/Domain/Content/ContentDomainIteratorSpec.php
@@ -1,6 +1,7 @@
 <?php
 namespace spec\EzSystems\EzPlatformGraphQL\Schema\Domain\Content;
 
+use Ibexa\GraphQL\Schema\Domain\NameValidator;
 use spec\EzSystems\EzPlatformGraphQL\Tools\TypeArgument;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
@@ -13,9 +14,11 @@ use EzSystems\EzPlatformGraphQL\Schema\Builder;
 
 class ContentDomainIteratorSpec extends ObjectBehavior
 {
-    public function let(ContentTypeService $contentTypeService)
-    {
-        $this->beConstructedWith($contentTypeService);
+    public function let(
+        ContentTypeService $contentTypeService,
+        NameValidator $nameValidator
+    ) {
+        $this->beConstructedWith($contentTypeService, $nameValidator);
     }
 
     function it_is_initializable()
@@ -54,8 +57,11 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     }
 
     function it_yields_content_types_with_their_group_from_a_content_type_group(
-        ContentTypeService $contentTypeService
+        ContentTypeService $contentTypeService,
+        NameValidator $nameValidator
     ) {
+        $nameValidator->isValidName(Argument::any())->willReturn(true);
+
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group = new ContentTypeGroup(['identifier' => 'Group']),
         ]);
@@ -76,8 +82,11 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     }
 
     function it_yields_fields_definitions_with_their_content_types_and_group_from_a_content_type(
-        ContentTypeService $contentTypeService
+        ContentTypeService $contentTypeService,
+        NameValidator $nameValidator
     ) {
+        $nameValidator->isValidName(Argument::any())->willReturn(true);
+
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group = new ContentTypeGroup(['identifier' => 'Group']),
         ]);
@@ -104,8 +113,11 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     }
 
     function it_only_yields_fields_definitions_from_the_current_content_type(
-        ContentTypeService $contentTypeService
+        ContentTypeService $contentTypeService,
+        NameValidator $nameValidator
     ) {
+        $nameValidator->isValidName(Argument::any())->willReturn(true);
+
         $contentTypeService->loadContentTypeGroups()->willReturn([
             $group = new ContentTypeGroup([
                 'identifier' => 'group'

--- a/src/Resources/config/services/schema.yml
+++ b/src/Resources/config/services/schema.yml
@@ -19,11 +19,7 @@ services:
 
     EzSystems\EzPlatformGraphQL\Schema\Builder\SchemaBuilder:
         arguments:
-            - '@Ibexa\GraphQL\Schema\Domain\NameValidator'
-        calls:
-            - method: setLogger
-              arguments:
-                  - '@logger'
+            $nameValidator: '@Ibexa\GraphQL\Schema\Domain\NameValidator'
 
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper:
         alias: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\DefaultFieldDefinitionMapper
@@ -87,9 +83,15 @@ services:
 
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\NameHelper: ~
 
-    Ibexa\GraphQL\Schema\Domain\NameValidator: ~
+    Ibexa\GraphQL\Schema\Domain\NameValidator:
+        calls:
+            - method: setLogger
+              arguments:
+                  - '@logger'
 
-    EzSystems\EzPlatformGraphQL\Schema\Domain\ImageVariationDomain: ~
+    EzSystems\EzPlatformGraphQL\Schema\Domain\ImageVariationDomain:
+        arguments:
+            $nameValidator: '@Ibexa\GraphQL\Schema\Domain\NameValidator'
 
     EzSystems\EzPlatformGraphQL\Schema\Domain\Content\ContentDomainIterator: ~
 

--- a/src/Schema/Builder/SchemaBuilder.php
+++ b/src/Schema/Builder/SchemaBuilder.php
@@ -8,14 +8,9 @@ namespace EzSystems\EzPlatformGraphQL\Schema\Builder;
 
 use EzSystems\EzPlatformGraphQL\Schema\Builder as SchemaBuilderInterface;
 use Ibexa\GraphQL\Schema\Domain\NameValidator;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
-use Psr\Log\NullLogger;
 
-class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
+class SchemaBuilder implements SchemaBuilderInterface
 {
-    use LoggerAwareTrait;
-
     private $schema = [];
 
     /** @var \Ibexa\GraphQL\Schema\Domain\NameValidator */
@@ -24,7 +19,6 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
     public function __construct(NameValidator $nameValidator)
     {
         $this->nameValidator = $nameValidator;
-        $this->logger = new NullLogger();
     }
 
     public function getSchema(): array
@@ -35,7 +29,7 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
     public function addType(Input\Type $typeInput)
     {
         if (!$this->nameValidator->isValidName($typeInput->name)) {
-            $this->generateInvalidGraphQLNameWarning($typeInput->type, $typeInput->name);
+            $this->nameValidator->generateInvalidNameWarning($typeInput->type, $typeInput->name);
 
             return;
         }
@@ -65,7 +59,7 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
     public function addFieldToType($type, Input\Field $fieldInput)
     {
         if (!$this->nameValidator->isValidName($fieldInput->name)) {
-            $this->generateInvalidGraphQLNameWarning($fieldInput->type, $fieldInput->name);
+            $this->nameValidator->generateInvalidNameWarning($fieldInput->type, $fieldInput->name);
 
             return;
         }
@@ -176,13 +170,5 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
     public function hasEnum($enum): bool
     {
         return $this->hasType($enum);
-    }
-
-    private function generateInvalidGraphQLNameWarning(string $type, string $name): void
-    {
-        $message = "Skipping schema generation for %s with identifier '%s' as it stands against GraphQL specification. "
-            . 'For more details see http://spec.graphql.org/[latest-release]/#sec-Names.';
-
-        $this->logger->warning(sprintf($message, $type, $name));
     }
 }

--- a/src/Schema/Domain/Content/ContentDomainIterator.php
+++ b/src/Schema/Domain/Content/ContentDomainIterator.php
@@ -11,15 +11,22 @@ use EzSystems\EzPlatformGraphQL\Schema\Builder;
 use EzSystems\EzPlatformGraphQL\Schema\Builder\Input;
 use EzSystems\EzPlatformGraphQL\Schema\Domain\Iterator;
 use Generator;
+use Ibexa\GraphQL\Schema\Domain\NameValidator;
 
 class ContentDomainIterator implements Iterator
 {
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
 
-    public function __construct(ContentTypeService $contentTypeService)
-    {
+    /** @var \Ibexa\GraphQL\Schema\Domain\NameValidator */
+    private $nameValidator;
+
+    public function __construct(
+        ContentTypeService $contentTypeService,
+        NameValidator $nameValidator
+    ) {
         $this->contentTypeService = $contentTypeService;
+        $this->nameValidator = $nameValidator;
     }
 
     public function init(Builder $schema)
@@ -35,6 +42,12 @@ class ContentDomainIterator implements Iterator
             yield ['ContentTypeGroup' => $contentTypeGroup];
 
             foreach ($this->contentTypeService->loadContentTypes($contentTypeGroup) as $contentType) {
+                if (!$this->nameValidator->isValidName($contentType->identifier)) {
+                    $this->nameValidator->generateInvalidNameWarning('Content Type', $contentType->identifier);
+
+                    continue;
+                }
+
                 yield ['ContentTypeGroup' => $contentTypeGroup]
                     + ['ContentType' => $contentType];
 

--- a/src/Schema/Domain/NameValidator.php
+++ b/src/Schema/Domain/NameValidator.php
@@ -8,15 +8,34 @@ declare(strict_types=1);
 
 namespace Ibexa\GraphQL\Schema\Domain;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+
 /**
  * Validates given name according to GraphQL specification. See http://spec.graphql.org/June2018/#sec-Names.
  */
-class NameValidator
+class NameValidator implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     private const NAME_PATTERN = '/^[_a-zA-Z][_a-zA-Z0-9]*$/';
+
+    public function __construct()
+    {
+        $this->logger = new NullLogger();
+    }
 
     public function isValidName(string $name): bool
     {
         return preg_match(self::NAME_PATTERN, $name) === 1;
+    }
+
+    public function generateInvalidNameWarning(string $type, string $name): void
+    {
+        $message = "Skipping schema generation for %s with identifier '%s' as it stands against GraphQL specification. "
+            . 'For more details see http://spec.graphql.org/[latest-release]/#sec-Names.';
+
+        $this->logger->warning(sprintf($message, $type, $name));
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2155](https://issues.ibexa.co/browse/IBX-2155)
| **Type**                                   | bug
| **Target version** | `v2.5`
| **BC breaks**                          | no

Some enum values should be handled before creating a schema. Therefore validation has been refactored.

Related PR: https://github.com/ezsystems/ezplatform-page-fieldtype/pull/224