### PR TITLE
IBX-1993: Added dependencies to `ibexa/graphql-php` fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ezsystems/ezplatform-admin-ui": "^2.0@dev",
         "ezsystems/ezplatform-rest": "^1.2@dev",
         "ezsystems/ezplatform-richtext": "^2.0@dev",
-        "ibexa/graphql-php": "^0.13.x",
+        "ibexa/graphql-php": "^0.13",
         "lexik/jwt-authentication-bundle": "^2.8",
         "overblog/graphql-bundle": "^0.13",
         "erusev/parsedown": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ezsystems/ezplatform-admin-ui": "^2.0@dev",
         "ezsystems/ezplatform-rest": "^1.2@dev",
         "ezsystems/ezplatform-richtext": "^2.0@dev",
+        "ibexa/graphql-php": "^0.13.x",
         "lexik/jwt-authentication-bundle": "^2.8",
         "overblog/graphql-bundle": "^0.13",
         "erusev/parsedown": "^1.7",


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-1993

Related to https://github.com/ibexa/graphql-php/pull/1.

Introducing https://github.com/ibexa/graphql-php being a fork of https://github.com/webonyx/graphql-php which is needed to fix PHP8 deprecation warnings. Aiming to not introduce BC break caused by bumping `overblog/graphql` dependency to `0.14`.