### PR TITLE
IBX-4542: Implemented `ImageAdditionalData` type

### DIFF
--- a/src/Resources/config/graphql/Field.types.yaml
+++ b/src/Resources/config/graphql/Field.types.yaml
@@ -36,6 +36,9 @@ ImageFieldValue:
             height:
                 type: "Int"
                 resolve: "@=value.height"
+            additionalData:
+                type: "ImageAdditionalData"
+                resolve: "@=value.additionalData"
             variations:
                 type: "[ImageVariation]"
                 args:
@@ -50,6 +53,17 @@ ImageFieldValue:
                         type: ImageVariationIdentifier!
                         description: "A variation identifier."
                 resolve: "@=resolver('ImageVariation', [value.value, args])"
+
+ImageAdditionalData:
+    type: object
+    config:
+        fields:
+            focalPointX:
+                type: "Int"
+                description: "The X value of focal point"
+            focalPointY:
+                type: "Int"
+                description: "The Y value of focal point"
 
 ImageVariation:
     type: object


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4542](https://issues.ibexa.co/browse/IBX-4542)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Example query:
```
{
  media {
    image (id: 261) {
      id,
      name,
      image {
        id,
        fileName,
        fileSize,
        additionalData {
          focalPointX,
          focalPointY
        }
      }
    }
  }
}
```